### PR TITLE
Add conversation assist drafting

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,7 +2,7 @@
   "version": "2.0.0",
   "tasks": [
     {
-      "label": "Release",
+      "label": "CT: Release",
       "command": "dotnet",
       "type": "process",
       "args": [
@@ -15,7 +15,7 @@
       "problemMatcher": "$msCompile"
     },
     {
-      "label": "Build All",
+      "label": "CT: Build All",
       "command": "dotnet",
       "type": "process",
       "args": [
@@ -26,7 +26,7 @@
       "problemMatcher": "$msCompile"
     },
     {
-      "label": "Build Server",
+      "label": "CT: Build Server",
       "command": "dotnet",
       "type": "process",
       "args": [
@@ -37,7 +37,7 @@
       "problemMatcher": "$msCompile"
     },
     {
-      "label": "UI Install",
+      "label": "CT: UI Install",
       "type": "shell",
       "command": "npm install",
       "options": {
@@ -52,9 +52,12 @@
       }
     },
     {
-      "label": "UI Build",
+      "label": "CT: UI Build",
       "type": "shell",
       "command": "npm run build --prefix app && xcopy /y /e /i dist ${workspaceFolder}\\bin\\x64\\Debug\\net472\\dist",
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
       "windows": {
           "command": "cmd",
           "args": [
@@ -71,12 +74,12 @@
       }
     },
     {
-      "label": "Fast Run",
+      "label": "CT: Fast Run",
       "command": "${workspaceFolder}/bin/x64/Debug/net472/ConverseTek.exe",
       "type": "shell"
     },
     {
-      "label": "UI-Only Run",
+      "label": "CT: UI-Only Run",
       "command": "npm start",
       "options": {
         "cwd": "${workspaceFolder}/app/"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,10 @@ Read `docs/architecture/overview.md` before larger changes, then the specific ar
 
 Do not register GET and POST handlers on the exact same route path. This Chromely version can collide or shadow routes by path even when the HTTP verb differs, causing frontend GET promises to never resolve. Use distinct paths such as `GET /ai/settings/current` and `POST /ai/settings`.
 
+## Frontend CSS
+
+The embedded Chromely/CEF runtime may lag behind modern browser CSS support. Avoid relying on `gap` for flex layouts in app UI; use explicit margins or margin fallbacks for spacing between flex children, especially in modal controls, tag lists, toolbars, and wrapped button rows. CSS Grid `gap` is acceptable where already verified in the runtime.
+
 ## AI Drafting
 
 AI-assisted conversation drafting is advisory only. Drafts must stay outside `dataStore.unsavedActiveConversationAsset` until the user accepts them.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ AI-assisted conversation drafting is advisory only. Drafts must stay outside `da
 
 - Global AI settings live in `config/ai.json`.
 - Workspace AI settings are keyed by conversation folder inside `config/ai.json`; do not create loose settings files in mod `conversations/` folders.
+- Workspace cast personalities live inside `config/ai.json`; built-in default personalities live in `config/ai-personalities.json`. Keep defaults editable, preserve explicit empty lists, and apply them through provider prompts rather than hard-coding character voice into draft conversion.
 - Backend provider work goes through `Services/AiProviderService.cs`; keep provider names generic so Codex, Claude Code, and future CLIs can share the interface.
 - Frontend draft conversion lives in `app/src/utils/ai-draft-utils.ts`; keep these functions pure and return fresh conversation assets or explicit patch objects.
 - Accepting a full draft must use "Turn Into Real Conversation"; node or branch suggestions must remain "Accept" / "Reject" until accepted.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# ConverseTek Agent Guidance
+
+This file is the canonical local guidance for coding agents in this repository. Also follow the workspace-level `AGENTS.md` when working from the multi-root ConverseTek workspace.
+
+## Language
+
+Use UK English in prose, docs, comments, commit messages, PR text, and issue text. Keep existing identifiers as-is when they already use US spelling.
+
+## Project Shape
+
+ConverseTek is a React + TypeScript + MobX frontend in `app/`, hosted by a C#/.NET Framework 4.7.2 Chromely backend at the repository root. The backend reads and writes BattleTech protobuf `.bytes` conversation files through the game DLLs in `libs/`.
+
+Read `docs/architecture/overview.md` before larger changes, then the specific architecture document for the area being touched.
+
+## Chromely Routing
+
+Do not register GET and POST handlers on the exact same route path. This Chromely version can collide or shadow routes by path even when the HTTP verb differs, causing frontend GET promises to never resolve. Use distinct paths such as `GET /ai/settings/current` and `POST /ai/settings`.
+
+## AI Drafting
+
+AI-assisted conversation drafting is advisory only. Drafts must stay outside `dataStore.unsavedActiveConversationAsset` until the user accepts them.
+
+- Global AI settings live in `config/ai.json`.
+- Workspace AI settings are keyed by conversation folder inside `config/ai.json`; do not create loose settings files in mod `conversations/` folders.
+- Backend provider work goes through `Services/AiProviderService.cs`; keep provider names generic so Codex, Claude Code, and future CLIs can share the interface.
+- Frontend draft conversion lives in `app/src/utils/ai-draft-utils.ts`; keep these functions pure and return fresh conversation assets or explicit patch objects.
+- Accepting a full draft must use "Turn Into Real Conversation"; node or branch suggestions must remain "Accept" / "Reject" until accepted.
+
+## Verification
+
+Always run the relevant lint and test commands before handing work back. For frontend changes, run `npm run ts-check` from `app/`, the configured lint command if present, and the relevant Vitest suite. For backend changes, run `dotnet build ConverseTek.csproj /t:BuildServer` from the repo root when game DLLs are available. If a lint or test command is missing, blocked, or not relevant to the touched area, say that explicitly in the final response.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-Guidance for Claude Code when working in this repository.
+Guidance for Claude Code when working in this repository. `AGENTS.md` is the canonical local guidance for coding agents; keep this file compatible with it.
 
 ## What this project is
 
@@ -34,6 +34,14 @@ For architecture detail, read the docs under [`docs/architecture/`](./docs/archi
 - API calls go through `app/src/services/api.ts`, which wraps the Chromely bridge in `app/src/services/rest.ts`. Don't call the bridge directly from components.
 - Backend controllers live in `Controllers/`, services in `Services/`. Services follow a singleton `getInstance()` pattern.
 - Prefer editing existing files over creating new ones. Don't add comments that explain *what* the code does — only *why* when non-obvious.
+
+## AI drafting
+
+- AI-assisted drafting is advisory until accepted. Keep draft preview data outside `dataStore.unsavedActiveConversationAsset`.
+- Global AI settings live in `config/ai.json`; workspace AI context is keyed by conversation folder inside that file. Do not write loose AI settings into a mod `conversations/` folder.
+- Backend AI providers go through `Services/AiProviderService.cs`; Codex CLI is the first provider, but provider names should stay generic for future CLIs.
+- Frontend draft conversion lives in `app/src/utils/ai-draft-utils.ts` and should return fresh conversation assets or explicit patch objects.
+- Full drafts use "Turn Into Real Conversation"; node/branch suggestions use "Accept" / "Reject".
 
 ## Important quirks
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,7 @@ For architecture detail, read the docs under [`docs/architecture/`](./docs/archi
 
 - AI-assisted drafting is advisory until accepted. Keep draft preview data outside `dataStore.unsavedActiveConversationAsset`.
 - Global AI settings live in `config/ai.json`; workspace AI context is keyed by conversation folder inside that file. Do not write loose AI settings into a mod `conversations/` folder.
+- Workspace cast personalities live in `config/ai.json`; built-in default personalities live in `config/ai-personalities.json`. Defaults should remain editable, explicit empty lists should be preserved, and character voice rules should be applied through provider prompts.
 - Backend AI providers go through `Services/AiProviderService.cs`; Codex CLI is the first provider, but provider names should stay generic for future CLIs.
 - Frontend draft conversion lives in `app/src/utils/ai-draft-utils.ts` and should return fresh conversation assets or explicit patch objects.
 - Full drafts use "Turn Into Real Conversation"; node/branch suggestions use "Accept" / "Reject".

--- a/Controllers/AiController.cs
+++ b/Controllers/AiController.cs
@@ -1,0 +1,216 @@
+namespace ConverseTek.Controllers {
+  using System;
+  using System.IO;
+
+  using Newtonsoft.Json;
+  using Newtonsoft.Json.Linq;
+
+  using Chromely.Core.RestfulService;
+  using Chromely.Core.Infrastructure;
+
+  using ProtoBuf.Meta;
+  using isogame;
+
+  using ConverseTek.Data;
+  using ConverseTek.Services;
+
+  [ControllerProperty(Name = "AiController", Route = "ai")]
+  public class AiController : ChromelyController {
+    public AiController() {
+      this.RegisterGetRequest("/ai/settings/current", this.GetSettings);
+      this.RegisterPostRequest("/ai/settings", this.SaveSettings);
+      this.RegisterPostRequest("/ai/models", this.GetModels);
+      this.RegisterPostRequest("/ai/draft", this.CreateDraft);
+      this.RegisterPostRequest("/ai/draft-artifact", this.GetDraftArtifact);
+      this.RegisterPostRequest("/ai/validate-conversation", this.ValidateConversation);
+    }
+
+    private ChromelyResponse GetSettings(ChromelyRequest request) {
+      ConfigService configService = ConfigService.getInstance();
+      AiSettings settings = configService.GetAiSettings();
+
+      ChromelyResponse response = new ChromelyResponse();
+      response.Data = JsonConvert.SerializeObject(settings);
+      return response;
+    }
+
+    private ChromelyResponse SaveSettings(ChromelyRequest request) {
+      string postDataJson = (string)request.PostData.EnsureJson();
+      JObject data = JObject.Parse(postDataJson);
+      ConfigService configService = ConfigService.getInstance();
+
+      if (data["settings"] != null) {
+        AiSettings settings = JsonConvert.DeserializeObject<AiSettings>(data["settings"].ToString());
+        settings = configService.SaveAiSettings(settings);
+        ChromelyResponse settingsResponse = new ChromelyResponse();
+        settingsResponse.Data = JsonConvert.SerializeObject(settings);
+        return settingsResponse;
+      }
+
+      if (data["workspaceSettings"] != null) {
+        AiWorkspaceSettings workspaceSettings = JsonConvert.DeserializeObject<AiWorkspaceSettings>(data["workspaceSettings"].ToString());
+        AiSettings settings = configService.SaveAiWorkspaceSettings(workspaceSettings);
+        ChromelyResponse workspaceResponse = new ChromelyResponse();
+        workspaceResponse.Data = JsonConvert.SerializeObject(settings);
+        return workspaceResponse;
+      }
+
+      ChromelyResponse response = new ChromelyResponse();
+      response.Data = JsonConvert.SerializeObject(configService.GetAiSettings());
+      return response;
+    }
+
+    private ChromelyResponse GetModels(ChromelyRequest request) {
+      ChromelyResponse response = new ChromelyResponse();
+
+      try {
+        if (ConfigService.getInstance().GetAiSettings().Enabled == false) {
+          response.Data = JsonConvert.SerializeObject(new AiModelCatalogResult {
+            Success = false,
+            Error = "AI features are disabled in config/ai.json.",
+            Provider = "unknown"
+          });
+          return response;
+        }
+
+        string postDataJson = (string)request.PostData.EnsureJson();
+        JObject data = JObject.Parse(postDataJson);
+        bool forceRefresh = data["forceRefresh"] != null && data["forceRefresh"].Value<bool>();
+        AiSettings settings = data["settings"] == null
+          ? ConfigService.getInstance().GetAiSettings()
+          : JsonConvert.DeserializeObject<AiSettings>(data["settings"].ToString());
+
+        AiModelCatalogResult result = AiProviderService.getInstance().GetModels(settings, forceRefresh);
+        response.Data = JsonConvert.SerializeObject(result);
+      } catch (Exception error) {
+        response.Data = JsonConvert.SerializeObject(new AiModelCatalogResult {
+          Success = false,
+          Error = error.Message,
+          Provider = "unknown"
+        });
+      }
+
+      return response;
+    }
+
+    private ChromelyResponse CreateDraft(ChromelyRequest request) {
+      ChromelyResponse response = new ChromelyResponse();
+
+      try {
+        if (ConfigService.getInstance().GetAiSettings().Enabled == false) {
+          response.Data = JsonConvert.SerializeObject(new AiDraftRunResult {
+            Success = false,
+            Error = "AI features are disabled in config/ai.json.",
+            Provider = "unknown"
+          });
+          return response;
+        }
+
+        string postDataJson = (string)request.PostData.EnsureJson();
+        JObject data = JObject.Parse(postDataJson);
+        AiDraftRequest draftRequest = JsonConvert.DeserializeObject<AiDraftRequest>(data["request"].ToString());
+        AiDraftRunResult result = AiProviderService.getInstance().RunDraft(draftRequest);
+        response.Data = JsonConvert.SerializeObject(result);
+      } catch (Exception error) {
+        response.Data = JsonConvert.SerializeObject(new AiDraftRunResult {
+          Success = false,
+          Error = error.Message,
+          Provider = "unknown"
+        });
+      }
+
+      return response;
+    }
+
+    private ChromelyResponse GetDraftArtifact(ChromelyRequest request) {
+      ChromelyResponse response = new ChromelyResponse();
+      AiDraftArtifactResult result = new AiDraftArtifactResult {
+        Success = false,
+        Error = "",
+        Content = "",
+        Path = "",
+        Truncated = false
+      };
+
+      try {
+        if (ConfigService.getInstance().GetAiSettings().Enabled == false) {
+          result.Error = "AI features are disabled in config/ai.json.";
+          response.Data = JsonConvert.SerializeObject(result);
+          return response;
+        }
+
+        string postDataJson = (string)request.PostData.EnsureJson();
+        JObject data = JObject.Parse(postDataJson);
+        string path = data["path"] == null ? "" : data["path"].ToString();
+        result.Path = path;
+
+        if (string.IsNullOrEmpty(path)) {
+          result.Error = "No AI diagnostics artifact path was provided.";
+          response.Data = JsonConvert.SerializeObject(result);
+          return response;
+        }
+
+        string diagnosticsRoot = Path.GetFullPath(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "logs", "ai-drafts"));
+        string fullPath = Path.GetFullPath(path);
+        string diagnosticsRootWithSeparator = diagnosticsRoot.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) + Path.DirectorySeparatorChar;
+
+        if (!fullPath.StartsWith(diagnosticsRootWithSeparator, StringComparison.OrdinalIgnoreCase)) {
+          result.Error = "AI diagnostics artifact is outside the AI draft logs folder.";
+          response.Data = JsonConvert.SerializeObject(result);
+          return response;
+        }
+
+        if (!File.Exists(fullPath)) {
+          result.Error = "AI diagnostics artifact does not exist.";
+          response.Data = JsonConvert.SerializeObject(result);
+          return response;
+        }
+
+        const int maxCharacters = 200000;
+        string content = File.ReadAllText(fullPath);
+        if (content.Length > maxCharacters) {
+          content = content.Substring(0, maxCharacters);
+          result.Truncated = true;
+        }
+
+        result.Content = content;
+        result.Success = true;
+      } catch (Exception error) {
+        result.Success = false;
+        result.Error = error.Message;
+      }
+
+      response.Data = JsonConvert.SerializeObject(result);
+      return response;
+    }
+
+    private ChromelyResponse ValidateConversation(ChromelyRequest request) {
+      ChromelyResponse response = new ChromelyResponse();
+      ConversationValidationResult result = new ConversationValidationResult {
+        Success = false,
+        Error = ""
+      };
+
+      try {
+        string postDataJson = (string)request.PostData.EnsureJson();
+        JObject data = JObject.Parse(postDataJson);
+        ConversationAsset conversationAsset = JsonConvert.DeserializeObject<ConversationAsset>(data["conversationAsset"].ToString());
+
+        RuntimeTypeModel runtimeTypeModel = TypeModel.Create();
+        using (MemoryStream memoryStream = new MemoryStream()) {
+          runtimeTypeModel.Serialize(memoryStream, conversationAsset.Conversation);
+          memoryStream.Position = 0;
+          Conversation roundTrippedConversation = runtimeTypeModel.Deserialize(memoryStream, null, typeof(Conversation)) as Conversation;
+          result.Success = roundTrippedConversation != null;
+          result.Error = result.Success ? "" : "The generated conversation could not be read back after serialisation.";
+        }
+      } catch (Exception error) {
+        result.Success = false;
+        result.Error = error.Message;
+      }
+
+      response.Data = JsonConvert.SerializeObject(result);
+      return response;
+    }
+  }
+}

--- a/Controllers/AiController.cs
+++ b/Controllers/AiController.cs
@@ -30,7 +30,7 @@ namespace ConverseTek.Controllers {
       AiSettings settings = configService.GetAiSettings();
 
       ChromelyResponse response = new ChromelyResponse();
-      response.Data = JsonConvert.SerializeObject(settings);
+      response.Data = SerializeAiSettingsResponse(configService, settings);
       return response;
     }
 
@@ -43,7 +43,7 @@ namespace ConverseTek.Controllers {
         AiSettings settings = JsonConvert.DeserializeObject<AiSettings>(data["settings"].ToString());
         settings = configService.SaveAiSettings(settings);
         ChromelyResponse settingsResponse = new ChromelyResponse();
-        settingsResponse.Data = JsonConvert.SerializeObject(settings);
+        settingsResponse.Data = SerializeAiSettingsResponse(configService, settings);
         return settingsResponse;
       }
 
@@ -51,13 +51,19 @@ namespace ConverseTek.Controllers {
         AiWorkspaceSettings workspaceSettings = JsonConvert.DeserializeObject<AiWorkspaceSettings>(data["workspaceSettings"].ToString());
         AiSettings settings = configService.SaveAiWorkspaceSettings(workspaceSettings);
         ChromelyResponse workspaceResponse = new ChromelyResponse();
-        workspaceResponse.Data = JsonConvert.SerializeObject(settings);
+        workspaceResponse.Data = SerializeAiSettingsResponse(configService, settings);
         return workspaceResponse;
       }
 
       ChromelyResponse response = new ChromelyResponse();
-      response.Data = JsonConvert.SerializeObject(configService.GetAiSettings());
+      response.Data = SerializeAiSettingsResponse(configService, configService.GetAiSettings());
       return response;
+    }
+
+    private string SerializeAiSettingsResponse(ConfigService configService, AiSettings settings) {
+      JObject response = JObject.FromObject(settings);
+      response["DefaultCastPersonalities"] = JArray.FromObject(configService.GetAiCastPersonalityDefaults());
+      return response.ToString(Formatting.None);
     }
 
     private ChromelyResponse GetModels(ChromelyRequest request) {

--- a/Controllers/FileSystemController.cs
+++ b/Controllers/FileSystemController.cs
@@ -45,6 +45,16 @@ namespace ConverseTek.Controllers {
         IDictionary<string, object> requestParams = request.Parameters;
         string path = (string)requestParams["path"];
         bool includeFiles = (bool)requestParams["includeFiles"];
+        List<string> fileExtensions = new List<string>();
+
+        if (requestParams.ContainsKey("fileExtensions") && requestParams["fileExtensions"] != null) {
+          JArray extensionTokens = requestParams["fileExtensions"] as JArray;
+          if (extensionTokens != null) {
+            foreach (JToken extensionToken in extensionTokens) {
+              fileExtensions.Add(extensionToken.ToString());
+            }
+          }
+        }
 
         if (path == "Desktop") {
           path = Environment.GetFolderPath(Environment.SpecialFolder.Desktop);
@@ -59,7 +69,7 @@ namespace ConverseTek.Controllers {
         List<FsFile> files = new List<FsFile>();
 
         if (includeFiles) {
-          files = fileSystemService.GetFiles(path);
+          files = fileSystemService.GetFiles(path, fileExtensions);
         }
 
         FsView fsView = new FsView();

--- a/ConverseTek.csproj
+++ b/ConverseTek.csproj
@@ -65,10 +65,16 @@
   </ItemGroup>
 
   <Target Name="BuildServer" DependsOnTargets="Build">
+    <ItemGroup>
+      <ConfigFiles Include="$(ProjectDir)config\**\*.*" Exclude="$(ProjectDir)config\ai.json" />
+    </ItemGroup>
+
     <Exec Command="xcopy &quot;$(ProjectDir)dist&quot; &quot;$(TargetDir)dist&quot;   /i /s /r /y /c&#xD;&#xA;" />
     <Exec Command="xcopy &quot;$(ProjectDir)libs&quot; &quot;$(TargetDir)&quot;   /i /s /r /y /c&#xD;&#xA;" />
     <Exec Command="xcopy &quot;$(ProjectDir)defs&quot; &quot;$(TargetDir)defs&quot;   /i /s /r /y /c&#xD;&#xA;" />
-    <Exec Command="xcopy &quot;$(ProjectDir)config&quot; &quot;$(TargetDir)config&quot;   /i /s /r /y /c&#xD;&#xA;" />
+    <MakeDir Directories="$(TargetDir)config" />
+    <Copy SourceFiles="@(ConfigFiles)" DestinationFiles="@(ConfigFiles->'$(TargetDir)config\%(RecursiveDir)%(Filename)%(Extension)')" />
+    <Copy SourceFiles="$(ProjectDir)config\ai.json" DestinationFiles="$(TargetDir)config\ai.json" Condition="!Exists('$(TargetDir)config\ai.json')" />
   </Target>
 
   <Target Name="BuildDebug" Condition=" '$(Configuration)' == 'Debug' ">

--- a/Data/AiDraft.cs
+++ b/Data/AiDraft.cs
@@ -1,0 +1,68 @@
+namespace ConverseTek.Data {
+  using System.Collections.Generic;
+
+  public class AiDraftRequest {
+    public string Mode { get; set; }
+    public string Brief { get; set; }
+    public string WorkingDirectory { get; set; }
+    public string ConversationJson { get; set; }
+    public string SelectedNodeJson { get; set; }
+    public string DefinitionsJson { get; set; }
+  }
+
+  public class AiDraftProviderRequest {
+    public AiDraftRequest Request { get; set; }
+    public AiSettings Settings { get; set; }
+    public AiWorkspaceSettings WorkspaceSettings { get; set; }
+    public List<AiContextFile> ContextFiles { get; set; }
+  }
+
+  public class AiContextFile {
+    public string Path { get; set; }
+    public string Content { get; set; }
+    public bool Truncated { get; set; }
+  }
+
+  public class AiDraftRunResult {
+    public bool Success { get; set; }
+    public string Error { get; set; }
+    public string Provider { get; set; }
+    public string DiagnosticsDirectory { get; set; }
+    public string RequestPath { get; set; }
+    public string PromptPath { get; set; }
+    public string OutputPath { get; set; }
+    public string StdoutPath { get; set; }
+    public string StderrPath { get; set; }
+    public string DraftJson { get; set; }
+  }
+
+  public class AiDraftArtifactResult {
+    public bool Success { get; set; }
+    public string Error { get; set; }
+    public string Path { get; set; }
+    public string Content { get; set; }
+    public bool Truncated { get; set; }
+  }
+
+  public class ConversationValidationResult {
+    public bool Success { get; set; }
+    public string Error { get; set; }
+  }
+
+  public class AiModelOption {
+    public string Slug { get; set; }
+    public string DisplayName { get; set; }
+    public string Description { get; set; }
+    public string DefaultReasoningLevel { get; set; }
+    public int Priority { get; set; }
+  }
+
+  public class AiModelCatalogResult {
+    public bool Success { get; set; }
+    public string Error { get; set; }
+    public string Provider { get; set; }
+    public string DefaultModel { get; set; }
+    public bool FromCache { get; set; }
+    public List<AiModelOption> Models { get; set; }
+  }
+}

--- a/Data/AiSettings.cs
+++ b/Data/AiSettings.cs
@@ -30,14 +30,26 @@ namespace ConverseTek.Data {
     public List<string> ContextPaths { get; set; }
     public string HouseStyleNotes { get; set; }
     public string DefaultCampaignBrief { get; set; }
+    public List<AiCastPersonality> CastPersonalities { get; set; }
 
     public static AiWorkspaceSettings CreateDefault(string workingDirectory) {
       return new AiWorkspaceSettings {
         WorkingDirectory = workingDirectory,
         ContextPaths = new List<string>(),
         HouseStyleNotes = "",
-        DefaultCampaignBrief = ""
+        DefaultCampaignBrief = "",
+        CastPersonalities = null
       };
     }
+  }
+
+  public class AiCastPersonality {
+    public string Id { get; set; }
+    public string Label { get; set; }
+    public List<string> CastIds { get; set; }
+    public List<string> SpeakerIds { get; set; }
+    public string Rules { get; set; }
+    public bool? Enabled { get; set; }
+    public string DefaultKey { get; set; }
   }
 }

--- a/Data/AiSettings.cs
+++ b/Data/AiSettings.cs
@@ -1,0 +1,43 @@
+namespace ConverseTek.Data {
+  using System.Collections.Generic;
+
+  public class AiSettings {
+    public bool? Enabled { get; set; }
+    public string SelectedProvider { get; set; }
+    public string CodexCommand { get; set; }
+    public string CodexModel { get; set; }
+    public string CodexProfile { get; set; }
+    public int TimeoutSeconds { get; set; }
+    public Dictionary<string, AiModelCatalogResult> ModelCatalogs { get; set; }
+    public Dictionary<string, AiWorkspaceSettings> Workspaces { get; set; }
+
+    public static AiSettings CreateDefault() {
+      return new AiSettings {
+        Enabled = true,
+        SelectedProvider = "codex",
+        CodexCommand = "codex",
+        CodexModel = "",
+        CodexProfile = "",
+        TimeoutSeconds = 300,
+        ModelCatalogs = new Dictionary<string, AiModelCatalogResult>(),
+        Workspaces = new Dictionary<string, AiWorkspaceSettings>()
+      };
+    }
+  }
+
+  public class AiWorkspaceSettings {
+    public string WorkingDirectory { get; set; }
+    public List<string> ContextPaths { get; set; }
+    public string HouseStyleNotes { get; set; }
+    public string DefaultCampaignBrief { get; set; }
+
+    public static AiWorkspaceSettings CreateDefault(string workingDirectory) {
+      return new AiWorkspaceSettings {
+        WorkingDirectory = workingDirectory,
+        ContextPaths = new List<string>(),
+        HouseStyleNotes = "",
+        DefaultCampaignBrief = ""
+      };
+    }
+  }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -62,8 +62,8 @@ namespace ConverseTek {
 
                 string startUrl = "local://dist/index.html";
 
-                int defaultScreenWidth = 1480;
-                int defaultScreenHeight = 900;
+                int defaultScreenWidth = 1720;
+                int defaultScreenHeight = 1000;
 
                 int screenWidth = Screen.PrimaryScreen.Bounds.Width - 100;
                 int screenHeight = Screen.PrimaryScreen.Bounds.Height - 100;

--- a/Services/AiProviderService.cs
+++ b/Services/AiProviderService.cs
@@ -400,9 +400,12 @@ namespace ConverseTek.Services {
       sb.AppendLine("- Produce an advisory draft only; ConverseTek will create real ids, indexes, and files after the user accepts.");
       sb.AppendLine("- Keep dialogue in BattleTech dropship conversation style: concise, voiced by the shown speaker, and readable in short UI bubbles.");
       sb.AppendLine("- Use speaker.type castId for known cast ids such as DariusDefault, SumireDefault, YangDefault, FarahDefault, KrakenIsabella, or BladesKai.");
-      sb.AppendLine("- Use speaker.type none for stage directions or non-speaker narration.");
+      sb.AppendLine("- Use speaker.type none only when the line should inherit the current BattleTech conversation speaker. BattleTech does not have a separate narration speaker for SimGame conversation nodes.");
       sb.AppendLine("- Every root or choice must either set targetKey to an existing node key or set endsConversation to true.");
-      sb.AppendLine("- Do not leave root or choice text blank. Use explicit short choices such as Continue, Understood, Ask Yang, or End conversation.");
+      sb.AppendLine("- For fullConversation, make the first root text an empty string and point it at the opening prompt node. Do not use Continue for that first root.");
+      sb.AppendLine("- For every other root or choice, use explicit short choices such as Understood, Ask Yang, or End conversation.");
+      sb.AppendLine("- For nodeSuggestion, return a text rewrite only. If the selected node is a prompt node, put the rewrite in nodes[0].text. If the selected node is a root or response, put the rewrite in roots[0].text. Leave the unused array empty.");
+      sb.AppendLine("- Write comment fields as short authoring notes that explain the beat, branch purpose, or condition context. Do not use draft keys such as darius_check as comments.");
       sb.AppendLine("- For operation intents, only use operation names present in the supplied definitions JSON. If unsure, leave operations empty and describe the concern in warnings.");
       sb.AppendLine("- Use mode from the request exactly.");
       sb.AppendLine();

--- a/Services/AiProviderService.cs
+++ b/Services/AiProviderService.cs
@@ -399,7 +399,7 @@ namespace ConverseTek.Services {
       sb.AppendLine("- Do not edit files.");
       sb.AppendLine("- Produce an advisory draft only; ConverseTek will create real ids, indexes, and files after the user accepts.");
       sb.AppendLine("- Keep dialogue in BattleTech dropship conversation style: concise, voiced by the shown speaker, and readable in short UI bubbles.");
-      sb.AppendLine("- Use speaker.type castId for known cast ids such as DariusDefault, SumireDefault, YangDefault, FarahDefault, KrakenIsabella, or BladesKai.");
+      sb.AppendLine("- Use speaker.type castId for known cast ids. Known cast ids include: " + FormatKnownCastIds(providerRequest.WorkspaceSettings) + ".");
       sb.AppendLine("- Use speaker.type none only when the line should inherit the current BattleTech conversation speaker. BattleTech does not have a separate narration speaker for SimGame conversation nodes.");
       sb.AppendLine("- Every root or choice must either set targetKey to an existing node key or set endsConversation to true.");
       sb.AppendLine("- For fullConversation, make the first root text an empty string and point it at the opening prompt node. Do not use Continue for that first root.");
@@ -419,6 +419,21 @@ namespace ConverseTek.Services {
         sb.AppendLine();
       }
 
+      sb.AppendLine("Cast personality rules:");
+      List<AiCastPersonality> relevantPersonalities = SelectRelevantCastPersonalities(providerRequest);
+      if (relevantPersonalities.Count == 0) {
+        sb.AppendLine("(none)");
+      } else {
+        sb.AppendLine("Apply these rules whenever a draft line uses a matching cast id or speaker id. Do not mention these rules in the draft output.");
+        foreach (AiCastPersonality personality in relevantPersonalities) {
+          sb.AppendLine("## " + (string.IsNullOrEmpty(personality.Label) ? personality.Id : personality.Label));
+          sb.AppendLine("Cast ids: " + FormatIdList(personality.CastIds));
+          sb.AppendLine("Speaker ids: " + FormatIdList(personality.SpeakerIds));
+          sb.AppendLine(personality.Rules);
+        }
+      }
+      sb.AppendLine();
+
       sb.AppendLine("Context files:");
       if (providerRequest.ContextFiles == null || providerRequest.ContextFiles.Count == 0) {
         sb.AppendLine("(none)");
@@ -437,6 +452,121 @@ namespace ConverseTek.Services {
       sb.AppendLine(requestJson);
       sb.AppendLine("```");
       return sb.ToString();
+    }
+
+    private string FormatKnownCastIds(AiWorkspaceSettings workspaceSettings) {
+      List<string> castIds = new List<string> {
+        "DariusDefault",
+        "SumireDefault",
+        "YangDefault",
+        "FarahDefault",
+        "KrakenIsabella",
+        "BladesKai",
+        "DEFAULT",
+        "HOLOGRAM"
+      };
+
+      if (workspaceSettings != null && workspaceSettings.CastPersonalities != null) {
+        foreach (AiCastPersonality personality in workspaceSettings.CastPersonalities) {
+          if (personality == null || personality.Enabled == false || personality.CastIds == null) continue;
+          foreach (string castId in personality.CastIds) {
+            AddUnique(castIds, castId);
+          }
+        }
+      }
+
+      return string.Join(", ", castIds.ToArray());
+    }
+
+    private List<AiCastPersonality> SelectRelevantCastPersonalities(AiDraftProviderRequest providerRequest) {
+      List<AiCastPersonality> relevantPersonalities = new List<AiCastPersonality>();
+      if (providerRequest == null || providerRequest.WorkspaceSettings == null || providerRequest.WorkspaceSettings.CastPersonalities == null) {
+        return relevantPersonalities;
+      }
+
+      string searchText = BuildCastPersonalitySearchText(providerRequest);
+      foreach (AiCastPersonality personality in providerRequest.WorkspaceSettings.CastPersonalities) {
+        if (!IsUsablePersonality(personality)) continue;
+        if (PersonalityMatchesText(personality, searchText)) {
+          relevantPersonalities.Add(personality);
+        }
+      }
+
+      if (relevantPersonalities.Count > 0) return relevantPersonalities;
+
+      foreach (AiCastPersonality personality in providerRequest.WorkspaceSettings.CastPersonalities) {
+        if (!IsUsablePersonality(personality)) continue;
+        if (!string.IsNullOrEmpty(personality.DefaultKey)) {
+          relevantPersonalities.Add(personality);
+        }
+      }
+
+      return relevantPersonalities;
+    }
+
+    private string BuildCastPersonalitySearchText(AiDraftProviderRequest providerRequest) {
+      if (providerRequest == null || providerRequest.Request == null) return "";
+
+      StringBuilder sb = new StringBuilder();
+      sb.AppendLine(providerRequest.Request.Brief ?? "");
+      sb.AppendLine(providerRequest.Request.ConversationJson ?? "");
+      sb.AppendLine(providerRequest.Request.SelectedNodeJson ?? "");
+      return sb.ToString();
+    }
+
+    private bool IsUsablePersonality(AiCastPersonality personality) {
+      return personality != null && personality.Enabled != false && !string.IsNullOrWhiteSpace(personality.Rules);
+    }
+
+    private bool PersonalityMatchesText(AiCastPersonality personality, string searchText) {
+      if (string.IsNullOrEmpty(searchText)) return false;
+
+      if (ContainsToken(searchText, personality.Label)) return true;
+      if (ContainsToken(searchText, personality.DefaultKey)) return true;
+
+      if (personality.CastIds != null) {
+        foreach (string castId in personality.CastIds) {
+          if (ContainsToken(searchText, castId)) return true;
+          if (!string.IsNullOrEmpty(castId) && castId.StartsWith("castDef_", StringComparison.OrdinalIgnoreCase)) {
+            if (ContainsToken(searchText, castId.Substring("castDef_".Length))) return true;
+          }
+        }
+      }
+
+      if (personality.SpeakerIds != null) {
+        foreach (string speakerId in personality.SpeakerIds) {
+          if (ContainsToken(searchText, speakerId)) return true;
+        }
+      }
+
+      return false;
+    }
+
+    private bool ContainsToken(string searchText, string token) {
+      if (string.IsNullOrWhiteSpace(token)) return false;
+      return searchText.IndexOf(token.Trim(), StringComparison.OrdinalIgnoreCase) >= 0;
+    }
+
+    private string FormatIdList(List<string> ids) {
+      if (ids == null || ids.Count == 0) return "(none)";
+
+      List<string> normalisedIds = new List<string>();
+      foreach (string id in ids) {
+        AddUnique(normalisedIds, id);
+      }
+
+      return normalisedIds.Count == 0 ? "(none)" : string.Join(", ", normalisedIds.ToArray());
+    }
+
+    private void AddUnique(List<string> values, string value) {
+      if (string.IsNullOrWhiteSpace(value)) return;
+
+      string trimmedValue = value.Trim();
+      foreach (string existingValue in values) {
+        if (string.Equals(existingValue, trimmedValue, StringComparison.OrdinalIgnoreCase)) return;
+      }
+
+      values.Add(trimmedValue);
     }
 
     private string CreateRunDirectory() {

--- a/Services/AiProviderService.cs
+++ b/Services/AiProviderService.cs
@@ -1,0 +1,532 @@
+namespace ConverseTek.Services {
+  using System;
+  using System.Collections.Generic;
+  using System.Diagnostics;
+  using System.IO;
+  using System.Text;
+
+  using Chromely.Core.Infrastructure;
+  using Newtonsoft.Json;
+  using Newtonsoft.Json.Linq;
+
+  using ConverseTek.Data;
+
+  public interface IAiProvider {
+    AiDraftRunResult RunDraft(AiDraftProviderRequest request);
+  }
+
+  public class AiProviderService {
+    private static AiProviderService instance;
+
+    public static AiProviderService getInstance() {
+      if (instance == null) instance = new AiProviderService();
+      return instance;
+    }
+
+    public AiDraftRunResult RunDraft(AiDraftRequest request) {
+      ConfigService configService = ConfigService.getInstance();
+      AiSettings settings = configService.GetAiSettings();
+      if (settings.Enabled == false) {
+        return new AiDraftRunResult {
+          Success = false,
+          Provider = settings.SelectedProvider ?? "unknown",
+          Error = "AI features are disabled in config/ai.json."
+        };
+      }
+
+      AiWorkspaceSettings workspaceSettings = configService.GetAiWorkspaceSettings(request.WorkingDirectory);
+
+      AiDraftProviderRequest providerRequest = new AiDraftProviderRequest {
+        Request = request,
+        Settings = settings,
+        WorkspaceSettings = workspaceSettings,
+        ContextFiles = LoadContextFiles(workspaceSettings)
+      };
+
+      IAiProvider provider = CreateProvider(settings.SelectedProvider);
+      return provider.RunDraft(providerRequest);
+    }
+
+    public AiModelCatalogResult GetModels(AiSettings settings, bool forceRefresh) {
+      settings = settings ?? ConfigService.getInstance().GetAiSettings();
+      if (settings.Enabled == false) {
+        return new AiModelCatalogResult {
+          Success = false,
+          Error = "AI features are disabled in config/ai.json.",
+          Provider = settings.SelectedProvider ?? "unknown",
+          DefaultModel = "",
+          FromCache = false,
+          Models = new List<AiModelOption>()
+        };
+      }
+
+      string normalisedProviderName = (settings.SelectedProvider ?? "").Trim().ToLowerInvariant();
+      if (normalisedProviderName == "") normalisedProviderName = "codex";
+
+      ConfigService configService = ConfigService.getInstance();
+      AiSettings savedSettings = configService.GetAiSettings();
+      AiModelCatalogResult cachedResult = GetCachedModelCatalog(savedSettings, normalisedProviderName);
+
+      if (!forceRefresh && cachedResult != null) {
+        cachedResult.FromCache = true;
+        return cachedResult;
+      }
+
+      if (normalisedProviderName == "" || normalisedProviderName == "codex") {
+        AiModelCatalogResult result = new CodexCliAiProvider().GetModels(settings);
+
+        if (result.Success && result.Models != null && result.Models.Count > 0) {
+          result.FromCache = false;
+          savedSettings.ModelCatalogs[normalisedProviderName] = result;
+          configService.SaveAiSettings(savedSettings);
+          return result;
+        }
+
+        if (cachedResult != null) {
+          cachedResult.FromCache = true;
+          cachedResult.Error = "Could not refresh provider models. Showing the last saved model list. " + result.Error;
+          return cachedResult;
+        }
+
+        return result;
+      }
+
+      return new AiModelCatalogResult {
+        Success = false,
+        Error = "AI provider '" + settings.SelectedProvider + "' does not expose model polling yet.",
+        Provider = normalisedProviderName,
+        DefaultModel = "",
+        FromCache = false,
+        Models = new List<AiModelOption>()
+      };
+    }
+
+    private AiModelCatalogResult GetCachedModelCatalog(AiSettings settings, string providerName) {
+      if (settings == null || settings.ModelCatalogs == null) return null;
+      if (!settings.ModelCatalogs.ContainsKey(providerName)) return null;
+
+      AiModelCatalogResult cachedResult = settings.ModelCatalogs[providerName];
+      if (cachedResult == null || cachedResult.Models == null || cachedResult.Models.Count == 0) return null;
+      return cachedResult;
+    }
+
+    private IAiProvider CreateProvider(string providerName) {
+      string normalisedProviderName = (providerName ?? "").Trim().ToLowerInvariant();
+      if (normalisedProviderName == "" || normalisedProviderName == "codex") {
+        return new CodexCliAiProvider();
+      }
+
+      throw new NotSupportedException("AI provider '" + providerName + "' is not supported yet.");
+    }
+
+    private List<AiContextFile> LoadContextFiles(AiWorkspaceSettings workspaceSettings) {
+      List<AiContextFile> files = new List<AiContextFile>();
+      if (workspaceSettings == null || workspaceSettings.ContextPaths == null) return files;
+
+      foreach (string path in workspaceSettings.ContextPaths) {
+        if (files.Count >= 16) break;
+        AddContextPath(files, path);
+      }
+
+      return files;
+    }
+
+    private void AddContextPath(List<AiContextFile> files, string path) {
+      if (string.IsNullOrEmpty(path)) return;
+
+      try {
+        if (File.Exists(path)) {
+          AddContextFile(files, path);
+          return;
+        }
+
+        if (!Directory.Exists(path)) return;
+
+        string[] candidateFiles = Directory.GetFiles(path, "*.*", SearchOption.AllDirectories);
+        Array.Sort(candidateFiles, StringComparer.OrdinalIgnoreCase);
+        foreach (string candidateFile in candidateFiles) {
+          if (files.Count >= 16) break;
+          if (IsSupportedContextFile(candidateFile)) {
+            AddContextFile(files, candidateFile);
+          }
+        }
+      } catch (Exception error) {
+        Log.Error("[AiProviderService] Could not load AI context path " + path + ": " + error.Message);
+      }
+    }
+
+    private void AddContextFile(List<AiContextFile> files, string path) {
+      if (!IsSupportedContextFile(path)) return;
+
+      string source = File.ReadAllText(path, Encoding.UTF8);
+      bool truncated = false;
+      if (source.Length > 40000) {
+        source = source.Substring(0, 40000);
+        truncated = true;
+      }
+
+      files.Add(new AiContextFile {
+        Path = path,
+        Content = source,
+        Truncated = truncated
+      });
+    }
+
+    private bool IsSupportedContextFile(string path) {
+      string extension = Path.GetExtension(path).ToLowerInvariant();
+      return extension == ".md" ||
+        extension == ".txt" ||
+        extension == ".json" ||
+        extension == ".jsonc" ||
+        extension == ".html" ||
+        extension == ".cs";
+    }
+  }
+
+  public class CodexCliAiProvider : IAiProvider {
+    private static string BASE_DIRECTORY = AppDomain.CurrentDomain.BaseDirectory;
+
+    public AiModelCatalogResult GetModels(AiSettings settings) {
+      AiModelCatalogResult result = new AiModelCatalogResult {
+        Success = false,
+        Provider = "codex",
+        DefaultModel = "",
+        FromCache = false,
+        Models = new List<AiModelOption>()
+      };
+
+      try {
+        Process process = CreateCodexModelsProcess(settings);
+        string stdout = "";
+        string stderr = "";
+
+        process.Start();
+        stdout = process.StandardOutput.ReadToEnd();
+        stderr = process.StandardError.ReadToEnd();
+        bool exited = process.WaitForExit(30000);
+
+        if (!exited) {
+          try {
+            process.Kill();
+          } catch {
+          }
+
+          result.Error = "Codex model polling timed out after 30 seconds.";
+          return result;
+        }
+
+        if (process.ExitCode != 0) {
+          result.Error = "Codex model polling exited with code " + process.ExitCode + ". " + FormatProcessOutputForDisplay(stderr == "" ? stdout : stderr);
+          return result;
+        }
+
+        JObject catalog = JObject.Parse(ExtractJsonObject(stdout));
+        JArray models = catalog["models"] as JArray;
+        if (models == null) {
+          result.Error = "Codex model polling returned no models array.";
+          return result;
+        }
+
+        foreach (JToken model in models) {
+          string visibility = model.Value<string>("visibility") ?? "";
+          if (visibility != "" && visibility != "list") continue;
+
+          result.Models.Add(new AiModelOption {
+            Slug = model.Value<string>("slug") ?? "",
+            DisplayName = model.Value<string>("display_name") ?? model.Value<string>("slug") ?? "",
+            Description = model.Value<string>("description") ?? "",
+            DefaultReasoningLevel = model.Value<string>("default_reasoning_level") ?? "",
+            Priority = model.Value<int?>("priority") ?? 0
+          });
+        }
+
+        result.Models.Sort((left, right) => left.Priority.CompareTo(right.Priority));
+        result.Success = true;
+        return result;
+      } catch (Exception error) {
+        result.Error = error.Message;
+        return result;
+      }
+    }
+
+    public AiDraftRunResult RunDraft(AiDraftProviderRequest providerRequest) {
+      AiDraftRunResult result = new AiDraftRunResult {
+        Success = false,
+        Provider = "codex"
+      };
+
+      string runDirectory = CreateRunDirectory();
+      result.DiagnosticsDirectory = runDirectory;
+      result.RequestPath = Path.Combine(runDirectory, "request.json");
+      result.PromptPath = Path.Combine(runDirectory, "prompt.md");
+      result.OutputPath = Path.Combine(runDirectory, "draft.json");
+      result.StdoutPath = Path.Combine(runDirectory, "stdout.log");
+      result.StderrPath = Path.Combine(runDirectory, "stderr.log");
+      string commandPath = Path.Combine(runDirectory, "command.txt");
+
+      string requestJson = JsonConvert.SerializeObject(providerRequest, Formatting.Indented);
+      string prompt = BuildPrompt(providerRequest, requestJson);
+      File.WriteAllText(result.RequestPath, requestJson, Encoding.UTF8);
+      File.WriteAllText(result.PromptPath, prompt, Encoding.UTF8);
+      File.WriteAllText(result.StdoutPath, "", Encoding.UTF8);
+      File.WriteAllText(result.StderrPath, "", Encoding.UTF8);
+
+      try {
+        Process process = CreateCodexProcess(providerRequest.Settings, result.OutputPath, commandPath);
+        StringBuilder stdoutBuilder = new StringBuilder();
+        StringBuilder stderrBuilder = new StringBuilder();
+        process.OutputDataReceived += (sender, args) => {
+          if (args.Data != null) stdoutBuilder.AppendLine(args.Data);
+        };
+        process.ErrorDataReceived += (sender, args) => {
+          if (args.Data != null) stderrBuilder.AppendLine(args.Data);
+        };
+
+        process.Start();
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+        process.StandardInput.Write(prompt);
+        process.StandardInput.Close();
+
+        bool exited = process.WaitForExit(providerRequest.Settings.TimeoutSeconds * 1000);
+
+        if (!exited) {
+          try {
+            process.Kill();
+          } catch {
+          }
+
+          result.Error = "Codex timed out after " + providerRequest.Settings.TimeoutSeconds + " seconds.";
+          return result;
+        }
+
+        process.WaitForExit();
+        string stdout = stdoutBuilder.ToString();
+        string stderr = stderrBuilder.ToString();
+        File.WriteAllText(result.StdoutPath, stdout, Encoding.UTF8);
+        File.WriteAllText(result.StderrPath, stderr, Encoding.UTF8);
+
+        if (process.ExitCode != 0) {
+          result.Error = "Codex exited with code " + process.ExitCode + ". " + FormatProcessOutputForDisplay(stderr == "" ? stdout : stderr);
+          return result;
+        }
+
+        if (!File.Exists(result.OutputPath)) {
+          result.Error = "Codex completed but did not write a draft output file.";
+          return result;
+        }
+
+        result.DraftJson = ExtractJsonObject(File.ReadAllText(result.OutputPath, Encoding.UTF8));
+        result.Success = true;
+        return result;
+      } catch (Exception error) {
+        result.Error = error.Message;
+        return result;
+      }
+    }
+
+    private Process CreateCodexProcess(AiSettings settings, string outputPath, string commandPath) {
+      string codexCommand = FindCodexCommand(settings);
+      string schemaPath = Path.Combine(BASE_DIRECTORY, "config", "ai-draft-output.schema.json");
+      if (!File.Exists(schemaPath)) {
+        schemaPath = Path.GetFullPath(Path.Combine(BASE_DIRECTORY, "..", "..", "..", "..", "config", "ai-draft-output.schema.json"));
+      }
+
+      StringBuilder command = new StringBuilder();
+      command.Append(QuoteForCmd(codexCommand));
+      command.Append(" --ask-for-approval never exec");
+      command.Append(" --sandbox read-only");
+      command.Append(" --ephemeral");
+      if (!string.IsNullOrEmpty(settings.CodexModel)) {
+        command.Append(" --model ").Append(QuoteForCmd(settings.CodexModel));
+      }
+      if (!string.IsNullOrEmpty(settings.CodexProfile)) {
+        command.Append(" --profile ").Append(QuoteForCmd(settings.CodexProfile));
+      }
+      command.Append(" --output-schema ").Append(QuoteForCmd(schemaPath));
+      command.Append(" --output-last-message ").Append(QuoteForCmd(outputPath));
+      command.Append(" -");
+
+      File.WriteAllText(commandPath, command.ToString(), Encoding.UTF8);
+
+      ProcessStartInfo startInfo = new ProcessStartInfo();
+      startInfo.FileName = "cmd.exe";
+      startInfo.Arguments = "/d /s /c \"" + command + "\"";
+      startInfo.WorkingDirectory = BASE_DIRECTORY;
+      startInfo.UseShellExecute = false;
+      startInfo.RedirectStandardInput = true;
+      startInfo.RedirectStandardOutput = true;
+      startInfo.RedirectStandardError = true;
+      startInfo.CreateNoWindow = true;
+
+      Process process = new Process();
+      process.StartInfo = startInfo;
+      return process;
+    }
+
+    private Process CreateCodexModelsProcess(AiSettings settings) {
+      string codexCommand = FindCodexCommand(settings);
+      StringBuilder command = new StringBuilder();
+      command.Append(QuoteForCmd(codexCommand));
+      if (!string.IsNullOrEmpty(settings.CodexProfile)) {
+        command.Append(" --profile ").Append(QuoteForCmd(settings.CodexProfile));
+      }
+      command.Append(" debug models");
+
+      ProcessStartInfo startInfo = new ProcessStartInfo();
+      startInfo.FileName = "cmd.exe";
+      startInfo.Arguments = "/d /s /c \"" + command + "\"";
+      startInfo.WorkingDirectory = BASE_DIRECTORY;
+      startInfo.UseShellExecute = false;
+      startInfo.RedirectStandardOutput = true;
+      startInfo.RedirectStandardError = true;
+      startInfo.CreateNoWindow = true;
+
+      Process process = new Process();
+      process.StartInfo = startInfo;
+      return process;
+    }
+
+    private string BuildPrompt(AiDraftProviderRequest providerRequest, string requestJson) {
+      StringBuilder sb = new StringBuilder();
+      sb.AppendLine("# ConverseTek AI Conversation Draft");
+      sb.AppendLine();
+      sb.AppendLine("You are drafting BattleTech dropship/SimGame conversations for ConverseTek.");
+      sb.AppendLine("Return only JSON matching the supplied schema.");
+      sb.AppendLine();
+      sb.AppendLine("Rules:");
+      sb.AppendLine("- Use British English.");
+      sb.AppendLine("- Do not edit files.");
+      sb.AppendLine("- Produce an advisory draft only; ConverseTek will create real ids, indexes, and files after the user accepts.");
+      sb.AppendLine("- Keep dialogue in BattleTech dropship conversation style: concise, voiced by the shown speaker, and readable in short UI bubbles.");
+      sb.AppendLine("- Use speaker.type castId for known cast ids such as DariusDefault, SumireDefault, YangDefault, FarahDefault, KrakenIsabella, or BladesKai.");
+      sb.AppendLine("- Use speaker.type none for stage directions or non-speaker narration.");
+      sb.AppendLine("- Every root or choice must either set targetKey to an existing node key or set endsConversation to true.");
+      sb.AppendLine("- Do not leave root or choice text blank. Use explicit short choices such as Continue, Understood, Ask Yang, or End conversation.");
+      sb.AppendLine("- For operation intents, only use operation names present in the supplied definitions JSON. If unsure, leave operations empty and describe the concern in warnings.");
+      sb.AppendLine("- Use mode from the request exactly.");
+      sb.AppendLine();
+      AiWorkspaceSettings workspaceSettings = providerRequest.WorkspaceSettings;
+      if (workspaceSettings != null) {
+        sb.AppendLine("Workspace house style notes:");
+        sb.AppendLine(string.IsNullOrEmpty(workspaceSettings.HouseStyleNotes) ? "(none)" : workspaceSettings.HouseStyleNotes);
+        sb.AppendLine();
+        sb.AppendLine("Default campaign brief:");
+        sb.AppendLine(string.IsNullOrEmpty(workspaceSettings.DefaultCampaignBrief) ? "(none)" : workspaceSettings.DefaultCampaignBrief);
+        sb.AppendLine();
+      }
+
+      sb.AppendLine("Context files:");
+      if (providerRequest.ContextFiles == null || providerRequest.ContextFiles.Count == 0) {
+        sb.AppendLine("(none)");
+      } else {
+        foreach (AiContextFile contextFile in providerRequest.ContextFiles) {
+          sb.AppendLine("## " + contextFile.Path + (contextFile.Truncated ? " (truncated)" : ""));
+          sb.AppendLine("```");
+          sb.AppendLine(contextFile.Content);
+          sb.AppendLine("```");
+        }
+      }
+
+      sb.AppendLine();
+      sb.AppendLine("Request JSON:");
+      sb.AppendLine("```json");
+      sb.AppendLine(requestJson);
+      sb.AppendLine("```");
+      return sb.ToString();
+    }
+
+    private string CreateRunDirectory() {
+      string directory = Path.Combine(BASE_DIRECTORY, "logs", "ai-drafts", DateTime.UtcNow.ToString("yyyyMMdd-HHmmss-fff"));
+      Directory.CreateDirectory(directory);
+      return directory;
+    }
+
+    private string FindCodexCommand(AiSettings settings) {
+      if (!string.IsNullOrEmpty(settings.CodexCommand) && settings.CodexCommand.Trim().ToLowerInvariant() != "codex") {
+        return settings.CodexCommand;
+      }
+
+      string path = Environment.GetEnvironmentVariable("PATH") ?? "";
+      string[] directories = path.Split(Path.PathSeparator);
+      string[] candidates = new string[] { "codex.cmd", "codex.exe", "codex" };
+
+      for (int i = 0; i < directories.Length; i++) {
+        for (int j = 0; j < candidates.Length; j++) {
+          string candidate = Path.Combine(directories[i], candidates[j]);
+          if (File.Exists(candidate)) {
+            return candidate;
+          }
+        }
+      }
+
+      string[] knownWindowsPaths = new string[] {
+        @"d:\Program Files\nodejs\codex.cmd",
+        @"C:\Program Files\nodejs\codex.cmd",
+        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "npm", "codex.cmd")
+      };
+
+      for (int i = 0; i < knownWindowsPaths.Length; i++) {
+        if (File.Exists(knownWindowsPaths[i])) {
+          return knownWindowsPaths[i];
+        }
+      }
+
+      return "codex";
+    }
+
+    private string ExtractJsonObject(string value) {
+      if (string.IsNullOrEmpty(value)) return "{}";
+      int start = value.IndexOf('{');
+      int end = value.LastIndexOf('}');
+      if (start >= 0 && end >= start) {
+        return value.Substring(start, end - start + 1);
+      }
+      return value;
+    }
+
+    private string TrimForDisplay(string value) {
+      if (string.IsNullOrEmpty(value)) return "";
+      value = value.Trim();
+      return value.Length > 1600 ? value.Substring(0, 1600) + "..." : value;
+    }
+
+    private string FormatProcessOutputForDisplay(string value) {
+      string providerError = ExtractProviderErrorMessage(value);
+      if (!string.IsNullOrEmpty(providerError)) return providerError;
+      return TrimForDisplay(value);
+    }
+
+    private string ExtractProviderErrorMessage(string value) {
+      if (string.IsNullOrEmpty(value)) return "";
+
+      int markerIndex = value.LastIndexOf("ERROR:", StringComparison.OrdinalIgnoreCase);
+      if (markerIndex < 0) return "";
+
+      string candidate = value.Substring(markerIndex + "ERROR:".Length).Trim();
+      string json = ExtractJsonObject(candidate);
+      if (string.IsNullOrEmpty(json) || json == "{}") return "";
+
+      try {
+        JObject errorEnvelope = JObject.Parse(json);
+        JToken errorToken = errorEnvelope["error"];
+        if (errorToken == null) return "";
+
+        string code = errorToken.Value<string>("code") ?? "";
+        string message = errorToken.Value<string>("message") ?? "";
+        string status = errorEnvelope["status"] == null ? "" : errorEnvelope["status"].ToString();
+        if (string.IsNullOrEmpty(message)) return "";
+
+        string prefix = string.IsNullOrEmpty(code) ? "" : code + ": ";
+        string suffix = string.IsNullOrEmpty(status) ? "" : " (status " + status + ")";
+        return prefix + message + suffix;
+      } catch {
+        return "";
+      }
+    }
+
+    private string QuoteForCmd(string value) {
+      return "\"" + value.Replace("\"", "\\\"") + "\"";
+    }
+  }
+}

--- a/Services/ConfigService.cs
+++ b/Services/ConfigService.cs
@@ -8,6 +8,8 @@ using Chromely.Core.Infrastructure;
 using Newtonsoft.Json;
 
 namespace ConverseTek.Services {
+  using ConverseTek.Data;
+
   public class ConfigService {
     private static ConfigService instance;
     private static string BASE_DIRECTORY = AppDomain.CurrentDomain.BaseDirectory;
@@ -15,6 +17,7 @@ namespace ConverseTek.Services {
 
     private static string QUICKLINKS_PATH = $"{CONFIG_PATH}/quicklinks.json";
     private static string COLOURS_PATH = $"{CONFIG_PATH}/colours.json";
+    private static string AI_PATH = $"{CONFIG_PATH}/ai.json";
 
     public static ConfigService getInstance() {
       if (instance == null) instance = new ConfigService();
@@ -34,6 +37,10 @@ namespace ConverseTek.Services {
       // Create quicklinks if it doesn't exist
       if (!File.Exists(COLOURS_PATH)) {
         File.WriteAllText(COLOURS_PATH, JsonConvert.SerializeObject(new object { }, Formatting.Indented));
+      }
+
+      if (!File.Exists(AI_PATH)) {
+        SaveAiSettings(AiSettings.CreateDefault());
       }
     }
 
@@ -92,6 +99,96 @@ namespace ConverseTek.Services {
         Log.Error(error.ToString());
         return null;
       }
+    }
+
+    public AiSettings GetAiSettings() {
+      try {
+        if (!File.Exists(AI_PATH)) {
+          SaveAiSettings(AiSettings.CreateDefault());
+        }
+
+        string json = File.ReadAllText(AI_PATH);
+        AiSettings settings = JsonConvert.DeserializeObject<AiSettings>(json);
+        return NormaliseAiSettings(settings);
+      } catch (Exception error) {
+        Log.Error(error.ToString());
+        return AiSettings.CreateDefault();
+      }
+    }
+
+    public AiSettings SaveAiSettings(AiSettings settings) {
+      if (settings == null) settings = AiSettings.CreateDefault();
+
+      AiSettings existingSettings = null;
+      if (File.Exists(AI_PATH)) {
+        existingSettings = JsonConvert.DeserializeObject<AiSettings>(File.ReadAllText(AI_PATH));
+      }
+
+      if ((settings.ModelCatalogs == null || settings.ModelCatalogs.Count == 0) &&
+        existingSettings != null &&
+        existingSettings.ModelCatalogs != null &&
+        existingSettings.ModelCatalogs.Count > 0) {
+        settings.ModelCatalogs = existingSettings.ModelCatalogs;
+      }
+
+      settings = NormaliseAiSettings(settings);
+      File.WriteAllText(AI_PATH, JsonConvert.SerializeObject(settings, Formatting.Indented));
+      return settings;
+    }
+
+    public AiWorkspaceSettings GetAiWorkspaceSettings(string workingDirectory) {
+      AiSettings settings = GetAiSettings();
+      string key = NormaliseWorkspaceKey(workingDirectory);
+
+      if (string.IsNullOrEmpty(key)) {
+        return AiWorkspaceSettings.CreateDefault("");
+      }
+
+      if (!settings.Workspaces.ContainsKey(key) || settings.Workspaces[key] == null) {
+        settings.Workspaces[key] = AiWorkspaceSettings.CreateDefault(workingDirectory);
+        SaveAiSettings(settings);
+      }
+
+      return NormaliseAiWorkspaceSettings(settings.Workspaces[key], workingDirectory);
+    }
+
+    public AiSettings SaveAiWorkspaceSettings(AiWorkspaceSettings workspaceSettings) {
+      AiSettings settings = GetAiSettings();
+      workspaceSettings = NormaliseAiWorkspaceSettings(workspaceSettings, workspaceSettings == null ? "" : workspaceSettings.WorkingDirectory);
+      string key = NormaliseWorkspaceKey(workspaceSettings.WorkingDirectory);
+
+      if (!string.IsNullOrEmpty(key)) {
+        settings.Workspaces[key] = workspaceSettings;
+      }
+
+      return SaveAiSettings(settings);
+    }
+
+    private AiSettings NormaliseAiSettings(AiSettings settings) {
+      if (settings == null) settings = AiSettings.CreateDefault();
+      if (settings.Enabled == null) settings.Enabled = true;
+      if (string.IsNullOrEmpty(settings.SelectedProvider)) settings.SelectedProvider = "codex";
+      if (string.IsNullOrEmpty(settings.CodexCommand)) settings.CodexCommand = "codex";
+      if (settings.CodexModel == null) settings.CodexModel = "";
+      if (settings.CodexProfile == null) settings.CodexProfile = "";
+      if (settings.TimeoutSeconds <= 0) settings.TimeoutSeconds = 300;
+      if (settings.ModelCatalogs == null) settings.ModelCatalogs = new Dictionary<string, AiModelCatalogResult>();
+      if (settings.Workspaces == null) settings.Workspaces = new Dictionary<string, AiWorkspaceSettings>();
+      return settings;
+    }
+
+    private AiWorkspaceSettings NormaliseAiWorkspaceSettings(AiWorkspaceSettings workspaceSettings, string fallbackWorkingDirectory) {
+      if (workspaceSettings == null) workspaceSettings = AiWorkspaceSettings.CreateDefault(fallbackWorkingDirectory);
+      if (workspaceSettings.WorkingDirectory == null) workspaceSettings.WorkingDirectory = fallbackWorkingDirectory ?? "";
+      if (workspaceSettings.ContextPaths == null) workspaceSettings.ContextPaths = new List<string>();
+      if (workspaceSettings.HouseStyleNotes == null) workspaceSettings.HouseStyleNotes = "";
+      if (workspaceSettings.DefaultCampaignBrief == null) workspaceSettings.DefaultCampaignBrief = "";
+      return workspaceSettings;
+    }
+
+    private string NormaliseWorkspaceKey(string workingDirectory) {
+      if (string.IsNullOrEmpty(workingDirectory)) return "";
+      return workingDirectory.Trim().Replace("\\", "/").TrimEnd('/').ToLowerInvariant();
     }
   }
 }

--- a/Services/ConfigService.cs
+++ b/Services/ConfigService.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using Chromely.Core.Infrastructure;
 
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace ConverseTek.Services {
   using ConverseTek.Data;
@@ -18,6 +19,7 @@ namespace ConverseTek.Services {
     private static string QUICKLINKS_PATH = $"{CONFIG_PATH}/quicklinks.json";
     private static string COLOURS_PATH = $"{CONFIG_PATH}/colours.json";
     private static string AI_PATH = $"{CONFIG_PATH}/ai.json";
+    private static string AI_PERSONALITIES_PATH = $"{CONFIG_PATH}/ai-personalities.json";
 
     public static ConfigService getInstance() {
       if (instance == null) instance = new ConfigService();
@@ -164,6 +166,28 @@ namespace ConverseTek.Services {
       return SaveAiSettings(settings);
     }
 
+    public List<AiCastPersonality> GetAiCastPersonalityDefaults() {
+      try {
+        if (!File.Exists(AI_PERSONALITIES_PATH)) return new List<AiCastPersonality>();
+
+        JObject config = JObject.Parse(File.ReadAllText(AI_PERSONALITIES_PATH));
+        JToken personalitiesToken = config["castPersonalities"] ?? config["CastPersonalities"];
+        if (personalitiesToken == null) return new List<AiCastPersonality>();
+
+        List<AiCastPersonality> personalities = JsonConvert.DeserializeObject<List<AiCastPersonality>>(personalitiesToken.ToString());
+        if (personalities == null) return new List<AiCastPersonality>();
+
+        for (int i = 0; i < personalities.Count; i++) {
+          personalities[i] = NormaliseAiCastPersonality(personalities[i]);
+        }
+
+        return personalities;
+      } catch (Exception error) {
+        Log.Error(error.ToString());
+        return new List<AiCastPersonality>();
+      }
+    }
+
     private AiSettings NormaliseAiSettings(AiSettings settings) {
       if (settings == null) settings = AiSettings.CreateDefault();
       if (settings.Enabled == null) settings.Enabled = true;
@@ -174,6 +198,11 @@ namespace ConverseTek.Services {
       if (settings.TimeoutSeconds <= 0) settings.TimeoutSeconds = 300;
       if (settings.ModelCatalogs == null) settings.ModelCatalogs = new Dictionary<string, AiModelCatalogResult>();
       if (settings.Workspaces == null) settings.Workspaces = new Dictionary<string, AiWorkspaceSettings>();
+      foreach (string key in new List<string>(settings.Workspaces.Keys)) {
+        AiWorkspaceSettings workspaceSettings = settings.Workspaces[key];
+        string fallbackWorkingDirectory = workspaceSettings == null ? "" : workspaceSettings.WorkingDirectory;
+        settings.Workspaces[key] = NormaliseAiWorkspaceSettings(workspaceSettings, fallbackWorkingDirectory);
+      }
       return settings;
     }
 
@@ -183,7 +212,23 @@ namespace ConverseTek.Services {
       if (workspaceSettings.ContextPaths == null) workspaceSettings.ContextPaths = new List<string>();
       if (workspaceSettings.HouseStyleNotes == null) workspaceSettings.HouseStyleNotes = "";
       if (workspaceSettings.DefaultCampaignBrief == null) workspaceSettings.DefaultCampaignBrief = "";
+      if (workspaceSettings.CastPersonalities == null) workspaceSettings.CastPersonalities = GetAiCastPersonalityDefaults();
+      for (int i = 0; i < workspaceSettings.CastPersonalities.Count; i++) {
+        workspaceSettings.CastPersonalities[i] = NormaliseAiCastPersonality(workspaceSettings.CastPersonalities[i]);
+      }
       return workspaceSettings;
+    }
+
+    private AiCastPersonality NormaliseAiCastPersonality(AiCastPersonality personality) {
+      if (personality == null) personality = new AiCastPersonality();
+      if (string.IsNullOrEmpty(personality.Id)) personality.Id = Guid.NewGuid().ToString("N");
+      if (personality.Label == null) personality.Label = "";
+      if (personality.CastIds == null) personality.CastIds = new List<string>();
+      if (personality.SpeakerIds == null) personality.SpeakerIds = new List<string>();
+      if (personality.Rules == null) personality.Rules = "";
+      if (personality.Enabled == null) personality.Enabled = true;
+      if (personality.DefaultKey == null) personality.DefaultKey = "";
+      return personality;
     }
 
     private string NormaliseWorkspaceKey(string workingDirectory) {

--- a/Services/FileSystemService.cs
+++ b/Services/FileSystemService.cs
@@ -86,14 +86,22 @@ namespace ConverseTek.Services {
       return directories;
     }
 
-    public List<FsFile> GetFiles(string path) {
+    public List<FsFile> GetFiles(string path, List<string> fileExtensions = null) {
       List<FsFile> files = new List<FsFile>();
 
       // Guard: No files at root
       if (path == "{drives}") return files;
 
       try {
-        string[] filePaths = Directory.GetFiles(path, "*.json");
+        List<string> searchExtensions = fileExtensions == null || fileExtensions.Count == 0 ? new List<string> { ".json" } : fileExtensions;
+        List<string> filePaths = new List<string>();
+
+        foreach (string extension in searchExtensions) {
+          string normalisedExtension = extension.StartsWith(".") ? extension : "." + extension;
+          filePaths.AddRange(Directory.GetFiles(path, "*" + normalisedExtension));
+        }
+
+        filePaths.Sort(StringComparer.OrdinalIgnoreCase);
         foreach (string filePath in filePaths) {
           FileInfo fileInfo = new FileInfo(filePath);
           FsFile file = new FsFile();

--- a/app/package.json
+++ b/app/package.json
@@ -10,6 +10,8 @@
     "build": "npm run verify && cross-env NODE_ENV=development CT_ENV=development webpack",
     "prod": "cross-env NODE_ENV=production CT_ENV=production webpack",
     "verify": "npm run ts-check",
+    "lint": "eslint src --ext .ts,.tsx,.js,.jsx",
+    "lint:fix": "eslint src --ext .ts,.tsx,.js,.jsx --fix",
     "test": "vitest run",
     "test:watch": "vitest",
     "ts-watch": "tsc --watch",

--- a/app/src/components/AiContextPathPicker/AiContextPathPicker.css
+++ b/app/src/components/AiContextPathPicker/AiContextPathPicker.css
@@ -1,0 +1,70 @@
+.ai-context-path-picker {
+  display: flex;
+  flex-direction: column;
+  min-height: 360px;
+}
+
+.ai-context-path-picker__alert {
+  margin-bottom: 10px;
+}
+
+.ai-context-path-picker__path {
+  margin-bottom: 8px;
+  padding: 6px 8px;
+  background: #fafafa;
+  color: #262626;
+  font-size: 12px;
+  overflow-wrap: anywhere;
+}
+
+.ai-context-path-picker__list {
+  min-height: 300px;
+  max-height: 52vh;
+  overflow: auto;
+}
+
+.ai-context-path-picker__loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 260px;
+}
+
+.ai-context-path-picker__item {
+  cursor: pointer;
+  padding: 0;
+}
+
+.ai-context-path-picker__item-content {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  min-height: 40px;
+  padding: 10px 8px;
+}
+
+.ai-context-path-picker__item:hover,
+.ai-context-path-picker__item:focus,
+.ai-context-path-picker__item--active {
+  background-color: #2ab0f77d;
+}
+
+.ai-context-path-picker__directory-icon,
+.ai-context-path-picker__file-icon {
+  flex: 0 0 auto;
+  margin-right: 10px;
+}
+
+.ai-context-path-picker__name {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  line-height: 1.25;
+}
+
+.ai-context-path-picker__kind {
+  flex: 0 0 auto;
+  margin-left: 10px;
+  color: #595959;
+  font-size: 12px;
+}

--- a/app/src/components/AiContextPathPicker/AiContextPathPicker.tsx
+++ b/app/src/components/AiContextPathPicker/AiContextPathPicker.tsx
@@ -1,0 +1,150 @@
+import React, { Fragment, useEffect, useRef, useState } from 'react';
+import { Alert, Icon, List, Spin } from 'antd';
+import classnames from 'classnames';
+import sortBy from 'lodash.sortby';
+
+import { useStore } from 'hooks/useStore';
+import { ModalStore } from 'stores/modalStore/modal-store';
+import { getDirectories, getRootDrives } from 'services/api';
+import { DirectoryItemType, FileItemSystemType, FileSystemItemType } from 'types';
+
+import './AiContextPathPicker.css';
+
+const ListItem = List.Item;
+const contextFileExtensions = ['.md', '.txt', '.json', '.jsonc', '.html', '.cs'];
+
+type Props = {
+  globalModalId: string;
+  initialPath?: string;
+  onSelectPath: (path: string) => void;
+};
+
+function getItemIcon(item: FileSystemItemType) {
+  if (item.isFile) return <Icon type="file-text" className="ai-context-path-picker__file-icon" />;
+  if (item.name === '..') return <Icon type="arrow-up" className="ai-context-path-picker__directory-icon" />;
+  return <Icon type={item.hasChildren ? 'folder-add' : 'folder'} className="ai-context-path-picker__directory-icon" />;
+}
+
+function AiContextPathPicker({ globalModalId, initialPath, onSelectPath }: Props) {
+  const modalStore = useStore<ModalStore>('modal');
+  const [loading, setLoading] = useState(false);
+  const [selectedItem, setSelectedItem] = useState<FileSystemItemType | null>(null);
+  const [directories, setDirectories] = useState<DirectoryItemType[]>([]);
+  const [files, setFiles] = useState<FileItemSystemType[]>([]);
+  const [currentPath, setCurrentPath] = useState(initialPath || '');
+  const listItemRefs = useRef<{ [key: string]: HTMLDivElement | null }>({});
+
+  const loadPath = (path: string) => {
+    setLoading(true);
+    setSelectedItem(null);
+    modalStore.setDisableOk(true, globalModalId);
+
+    if (path === '') {
+      void getRootDrives()
+        .then((updatedDirectories: DirectoryItemType[]) => {
+          setDirectories(updatedDirectories);
+          setFiles([]);
+          setCurrentPath('');
+        })
+        .finally(() => setLoading(false));
+      return;
+    }
+
+    void getDirectories(path, true, contextFileExtensions)
+      .then(({ directories: updatedDirectories, files: updatedFiles }: { directories: DirectoryItemType[]; files: FileItemSystemType[] }) => {
+        setDirectories(updatedDirectories);
+        setFiles(updatedFiles);
+        setCurrentPath(path);
+      })
+      .finally(() => setLoading(false));
+  };
+
+  const selectItem = (item: FileSystemItemType) => {
+    if (loading || item.name === '..') return;
+
+    const nextSelectedItem = selectedItem && selectedItem.path === item.path ? null : item;
+    setSelectedItem(nextSelectedItem);
+    modalStore.setDisableOk(nextSelectedItem == null, globalModalId);
+  };
+
+  const openDirectory = (item: DirectoryItemType) => {
+    if (loading) return;
+    loadPath(item.path === '{drives}' ? '' : item.path);
+  };
+
+  const setupModal = () => {
+    modalStore.setTitle(`Select AI Context Path${selectedItem ? ' - ' + selectedItem.name : ''}`, globalModalId);
+    modalStore.setWidth('58vw', globalModalId);
+    modalStore.setOkLabel('Add Path', globalModalId);
+    modalStore.setCancelLabel('Cancel', globalModalId);
+    modalStore.setDisableOk(selectedItem == null, globalModalId);
+    modalStore.setOnOk(() => {
+      if (!selectedItem) return;
+      onSelectPath(selectedItem.path);
+      modalStore.closeModal(globalModalId);
+    }, globalModalId);
+  };
+
+  useEffect(() => {
+    loadPath(initialPath || '');
+  }, []);
+
+  useEffect(() => {
+    setupModal();
+  });
+
+  useEffect(() => {
+    listItemRefs.current = {};
+  }, [directories, files]);
+
+  const items = [...sortBy(directories, (item) => item.name.toLowerCase()), ...sortBy(files, (item) => item.name.toLowerCase())];
+
+  return (
+    <div className="ai-context-path-picker">
+      <Alert
+        className="ai-context-path-picker__alert"
+        type="info"
+        message={`Choose a folder or one supported context file (${contextFileExtensions.join(', ')}).`}
+      />
+      {currentPath && <div className="ai-context-path-picker__path">{currentPath}</div>}
+      <div className="ai-context-path-picker__list">
+        {loading ? (
+          <div className="ai-context-path-picker__loading">
+            <Spin />
+          </div>
+        ) : (
+          <List
+            itemLayout="horizontal"
+            dataSource={items}
+            renderItem={(item: FileSystemItemType) => {
+              const itemClasses = classnames('ai-context-path-picker__item', {
+                'ai-context-path-picker__item--active': selectedItem != null && selectedItem.path === item.path,
+              });
+
+              return (
+                <ListItem key={item.path} className={itemClasses}>
+                  <div
+                    ref={(el) => (listItemRefs.current[item.path] = el)}
+                    className="ai-context-path-picker__item-content"
+                    onClick={() => selectItem(item)}
+                    onDoubleClick={() => item.isDirectory && openDirectory(item)}
+                  >
+                    {getItemIcon(item)}
+                    <span className="ai-context-path-picker__name">{item.name}</span>
+                    {item.isDirectory && item.name !== '..' && (
+                      <Fragment>
+                        <span className="ai-context-path-picker__kind">folder</span>
+                      </Fragment>
+                    )}
+                  </div>
+                </ListItem>
+              );
+            }}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+export const ObservingAiContextPathPicker = AiContextPathPicker;

--- a/app/src/components/AiContextPathPicker/index.ts
+++ b/app/src/components/AiContextPathPicker/index.ts
@@ -1,0 +1,1 @@
+export { ObservingAiContextPathPicker as AiContextPathPicker } from './AiContextPathPicker';

--- a/app/src/components/AiDraftModal/AiDraftArtifactViewer.tsx
+++ b/app/src/components/AiDraftModal/AiDraftArtifactViewer.tsx
@@ -45,7 +45,7 @@ export function AiDraftArtifactViewer({ globalModalId, title, path, content, tru
           </Button>
         </Button.Group>
         {viewMode === 'formatted' && formattedContent.notes.length > 0 && (
-          <span>{formattedContent.notes.join(' ')}</span>
+          <span className="ai-draft-artifact-viewer__note">{formattedContent.notes.join(' ')}</span>
         )}
       </div>
       {truncated && (

--- a/app/src/components/AiDraftModal/AiDraftArtifactViewer.tsx
+++ b/app/src/components/AiDraftModal/AiDraftArtifactViewer.tsx
@@ -1,0 +1,61 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Alert, Button } from 'antd';
+
+import { useStore } from 'hooks/useStore';
+import { ModalStore } from 'stores/modalStore/modal-store';
+import { formatAiDraftArtifactContent } from 'utils/ai-artifact-utils';
+
+type Props = {
+  globalModalId: string;
+  title: string;
+  path: string;
+  content: string;
+  truncated: boolean;
+};
+
+export function AiDraftArtifactViewer({ globalModalId, title, path, content, truncated }: Props) {
+  const modalStore = useStore<ModalStore>('modal');
+  const [viewMode, setViewMode] = useState<'formatted' | 'raw'>('formatted');
+  const formattedContent = useMemo(() => formatAiDraftArtifactContent(content), [content]);
+  const displayedContent = viewMode === 'formatted' ? formattedContent.formattedContent : content;
+
+  useEffect(() => {
+    modalStore.setTitle(title, globalModalId);
+    modalStore.setWidth('72vw', globalModalId);
+    modalStore.setShowOkButton(false, globalModalId);
+    modalStore.setShowCancelButton(true, globalModalId);
+    modalStore.setCancelLabel('Close', globalModalId);
+  }, []);
+
+  return (
+    <div className="ai-draft-artifact-viewer">
+      <div className="ai-draft-artifact-viewer__path">{path}</div>
+      <div className="ai-draft-artifact-viewer__toolbar">
+        <Button.Group>
+          <Button
+            size="small"
+            type={viewMode === 'formatted' ? 'primary' : 'default'}
+            disabled={!formattedContent.wasFormatted}
+            onClick={() => setViewMode('formatted')}
+          >
+            Formatted
+          </Button>
+          <Button size="small" type={viewMode === 'raw' ? 'primary' : 'default'} onClick={() => setViewMode('raw')}>
+            Raw
+          </Button>
+        </Button.Group>
+        {viewMode === 'formatted' && formattedContent.notes.length > 0 && (
+          <span>{formattedContent.notes.join(' ')}</span>
+        )}
+      </div>
+      {truncated && (
+        <Alert
+          className="ai-draft-artifact-viewer__alert"
+          type="warning"
+          message="This diagnostics artifact is large, so ConverseTek is showing the first part only."
+        />
+      )}
+      <pre>{displayedContent || '(empty)'}</pre>
+    </div>
+  );
+}

--- a/app/src/components/AiDraftModal/AiDraftConversationTreePreview.tsx
+++ b/app/src/components/AiDraftModal/AiDraftConversationTreePreview.tsx
@@ -14,8 +14,16 @@ import { ConversationAssetType, ElementNodeType, OperationCallType, PromptNodeTy
 import { getId } from 'utils/conversation-utils';
 
 type PreviewNodeStore = ConversationTreeNodeStore & {
-  buildTreeData: () => RSTNode[];
+  buildTreeData: () => PreviewTreeNode[];
   recordTreeIndex: (nodeId: string | undefined, treeIndex: number) => void;
+};
+
+type PreviewTreeNode = RSTNode & {
+  previewTreeKey: string;
+};
+
+type PreviewRowHeightProps = {
+  node: PreviewTreeNode;
 };
 
 type Props = {
@@ -28,7 +36,7 @@ export function AiDraftConversationTreePreview({ conversationAsset }: Props) {
   const treeContainerSize = useSize(treeContainerRef);
   const expansionByNodeId = useRef(new Map<string, boolean>());
   const [activeNodeId, setActiveNodeId] = useState<string | null>(null);
-  const [treeData, setTreeData] = useState<RSTNode[]>([]);
+  const [treeData, setTreeData] = useState<PreviewTreeNode[]>([]);
 
   const previewNodeStore = useMemo(
     () => createPreviewNodeStore(conversationAsset, expansionByNodeId.current, setActiveNodeId),
@@ -59,15 +67,15 @@ export function AiDraftConversationTreePreview({ conversationAsset }: Props) {
           <ScalableScrollbar activeNodeId={activeNodeId} width={10} hideScrollOnScale={false}>
             <SortableTree
               treeData={treeData}
-              onChange={(nextTreeData: RSTNode[]) => setTreeData(nextTreeData)}
-              getNodeKey={({ node, treeIndex }: { node: RSTNode; treeIndex: number }) => {
+              onChange={(nextTreeData: PreviewTreeNode[]) => setTreeData(nextTreeData)}
+              getNodeKey={({ node, treeIndex }: { node: PreviewTreeNode; treeIndex: number }) => {
                 previewNodeStore.recordTreeIndex(node.id, treeIndex);
-                return node.id || treeIndex;
+                return node.previewTreeKey || node.id || treeIndex;
               }}
-              rowHeight={56}
+              rowHeight={getPreviewRowHeight}
               canDrag={() => false}
               canDrop={() => false}
-              generateNodeProps={({ node }: { node: RSTNode }) => ({
+              generateNodeProps={({ node }: { node: PreviewTreeNode }) => ({
                 dataStore,
                 nodeStore: previewNodeStore,
                 activeNodeId,
@@ -117,9 +125,12 @@ function createPreviewNodeStore(
       {
         title: conversationAsset.conversation.uiName || 'AI Draft Conversation',
         id: '0',
+        previewTreeKey: 'core-0',
         type: 'core',
         parentId: '-1',
-        children: conversationAsset.conversation.roots.map((root) => buildElementTreeNode(root, 'root', null, previewNodeStore)),
+        children: conversationAsset.conversation.roots.map((root, index) =>
+          buildElementTreeNode(root, 'root', null, `core-0/root-${index}`, previewNodeStore),
+        ),
         expanded: true,
         canDrag: false,
       },
@@ -154,23 +165,30 @@ function buildElementTreeNode(
   elementNode: ElementNodeType,
   type: 'root' | 'response',
   parentId: string | null,
+  previewTreeKey: string,
   previewNodeStore: PreviewNodeStore,
-): RSTNode {
+): PreviewTreeNode {
   const elementNodeId = getId(elementNode);
 
   return {
     title: elementNode.responseText,
     subtitle: formatElementSubtitle(elementNode),
     id: elementNodeId,
+    previewTreeKey,
     parentId,
     type,
     expanded: previewNodeStore.isNodeExpanded(elementNodeId),
     canDrag: false,
-    children: buildElementChildren(elementNode, elementNodeId, previewNodeStore),
+    children: buildElementChildren(elementNode, elementNodeId, previewTreeKey, previewNodeStore),
   };
 }
 
-function buildElementChildren(elementNode: ElementNodeType, elementNodeId: string, previewNodeStore: PreviewNodeStore): RSTNode[] | null {
+function buildElementChildren(
+  elementNode: ElementNodeType,
+  elementNodeId: string,
+  parentTreeKey: string,
+  previewNodeStore: PreviewNodeStore,
+): PreviewTreeNode[] | null {
   if (elementNode.nextNodeIndex === -1) return null;
 
   if (elementNode.auxiliaryLink) {
@@ -179,6 +197,7 @@ function buildElementChildren(elementNode: ElementNodeType, elementNodeId: strin
       {
         title: `[Link to NODE ${elementNode.nextNodeIndex}]`,
         id: `link-${elementNodeId}-${elementNode.nextNodeIndex}`,
+        previewTreeKey: `${parentTreeKey}/link-${elementNode.nextNodeIndex}`,
         type: 'link',
         linkId: linkedPromptNode ? getId(linkedPromptNode) : null,
         linkIndex: elementNode.nextNodeIndex,
@@ -191,22 +210,41 @@ function buildElementChildren(elementNode: ElementNodeType, elementNodeId: strin
   const childPromptNode = previewNodeStore.getPromptNodeByIndex(elementNode.nextNodeIndex);
   if (!childPromptNode) return null;
 
-  return [buildPromptTreeNode(childPromptNode, elementNodeId, previewNodeStore)];
+  return [buildPromptTreeNode(childPromptNode, elementNodeId, `${parentTreeKey}/node-${elementNode.nextNodeIndex}`, previewNodeStore)];
 }
 
-function buildPromptTreeNode(promptNode: PromptNodeType, parentId: string, previewNodeStore: PreviewNodeStore): RSTNode {
+function buildPromptTreeNode(
+  promptNode: PromptNodeType,
+  parentId: string,
+  previewTreeKey: string,
+  previewNodeStore: PreviewNodeStore,
+): PreviewTreeNode {
   const promptNodeId = getId(promptNode);
 
   return {
     title: promptNode.text,
     subtitle: formatPromptSubtitle(promptNode),
     id: promptNodeId,
+    previewTreeKey,
     parentId,
     type: 'node',
     expanded: previewNodeStore.isNodeExpanded(promptNodeId),
     canDrag: false,
-    children: promptNode.branches.map((branch) => buildElementTreeNode(branch, 'response', promptNodeId, previewNodeStore)),
+    children: promptNode.branches.map((branch, index) =>
+      buildElementTreeNode(branch, 'response', promptNodeId, `${previewTreeKey}/response-${index}`, previewNodeStore),
+    ),
   };
+}
+
+function getPreviewRowHeight({ node }: PreviewRowHeightProps): number {
+  const title = typeof node.title === 'string' ? node.title : '';
+  const subtitle = typeof node.subtitle === 'string' ? node.subtitle : '';
+  const estimatedCharactersPerLine = node.type === 'response' ? 70 : 86;
+  const titleLines = Math.max(1, Math.ceil(title.length / estimatedCharactersPerLine));
+  const subtitleLines = subtitle.length > 0 ? Math.max(1, Math.ceil(subtitle.length / 96)) : 0;
+  const estimatedHeight = 40 + titleLines * 18 + subtitleLines * 14;
+
+  return Math.min(180, Math.max(64, estimatedHeight));
 }
 
 function formatPromptSubtitle(promptNode: PromptNodeType): string {
@@ -237,7 +275,7 @@ function formatSpeaker(promptNode: PromptNodeType): string {
   return 'Narration';
 }
 
-function buildPreviewNodeButtons(node: RSTNode, previewNodeStore: PreviewNodeStore): JSX.Element[] {
+function buildPreviewNodeButtons(node: PreviewTreeNode, previewNodeStore: PreviewNodeStore): JSX.Element[] {
   if (node.type !== 'node') return [];
 
   const promptNode = previewNodeStore.getNode(node.id);

--- a/app/src/components/AiDraftModal/AiDraftConversationTreePreview.tsx
+++ b/app/src/components/AiDraftModal/AiDraftConversationTreePreview.tsx
@@ -272,7 +272,7 @@ function formatElementSubtitle(elementNode: ElementNodeType): string {
 function formatSpeaker(promptNode: PromptNodeType): string {
   if (promptNode.speakerType === 'castId' && promptNode.sourceInSceneRef?.id) return promptNode.sourceInSceneRef.id;
   if (promptNode.speakerType === 'speakerId' && promptNode.speakerOverrideId) return promptNode.speakerOverrideId;
-  return 'Narration';
+  return 'Inherits';
 }
 
 function buildPreviewNodeButtons(node: PreviewTreeNode, previewNodeStore: PreviewNodeStore): JSX.Element[] {

--- a/app/src/components/AiDraftModal/AiDraftConversationTreePreview.tsx
+++ b/app/src/components/AiDraftModal/AiDraftConversationTreePreview.tsx
@@ -1,0 +1,264 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { Icon } from 'antd';
+import { useSize } from 'ahooks';
+import SortableTree from 'react-sortable-tree';
+
+import 'react-sortable-tree/style.css';
+
+import { ConverseTekNodeRenderer, ConversationTreeNodeStore, ConverseTekNodeRendererProps } from 'components/DialogEditor/ConverseTekNodeRenderer';
+import type { OnNodeContextMenuProps } from 'components/DialogEditor/DialogEditor';
+import { ScalableScrollbar } from 'components/ScalableScrollbar';
+import { useStore } from 'hooks/useStore';
+import { DataStore } from 'stores/dataStore/data-store';
+import { ConversationAssetType, ElementNodeType, OperationCallType, PromptNodeType } from 'types';
+import { getId } from 'utils/conversation-utils';
+
+type PreviewNodeStore = ConversationTreeNodeStore & {
+  buildTreeData: () => RSTNode[];
+  recordTreeIndex: (nodeId: string | undefined, treeIndex: number) => void;
+};
+
+type Props = {
+  conversationAsset: ConversationAssetType;
+};
+
+export function AiDraftConversationTreePreview({ conversationAsset }: Props) {
+  const dataStore = useStore<DataStore>('data');
+  const treeContainerRef = useRef<HTMLDivElement>(null);
+  const treeContainerSize = useSize(treeContainerRef);
+  const expansionByNodeId = useRef(new Map<string, boolean>());
+  const [activeNodeId, setActiveNodeId] = useState<string | null>(null);
+  const [treeData, setTreeData] = useState<RSTNode[]>([]);
+
+  const previewNodeStore = useMemo(
+    () => createPreviewNodeStore(conversationAsset, expansionByNodeId.current, setActiveNodeId),
+    [conversationAsset],
+  );
+
+  useEffect(() => {
+    setActiveNodeId(null);
+    setTreeData(previewNodeStore.buildTreeData());
+  }, [previewNodeStore]);
+
+  const ignoreContextMenu = ({ event }: OnNodeContextMenuProps) => {
+    event.preventDefault();
+  };
+
+  const treeWidth = treeContainerSize?.width || 0;
+
+  return (
+    <div className="ai-draft-preview-tree">
+      <div className="ai-draft-preview-tree__toolbar">
+        <span>
+          <Icon type="branches" /> Conversation tree preview
+        </span>
+        <span>Read-only</span>
+      </div>
+      <div ref={treeContainerRef} className="ai-draft-preview-tree__canvas">
+        {treeData.length > 0 && treeWidth > 0 && (
+          <ScalableScrollbar activeNodeId={activeNodeId} width={10} hideScrollOnScale={false}>
+            <SortableTree
+              treeData={treeData}
+              onChange={(nextTreeData: RSTNode[]) => setTreeData(nextTreeData)}
+              getNodeKey={({ node, treeIndex }: { node: RSTNode; treeIndex: number }) => {
+                previewNodeStore.recordTreeIndex(node.id, treeIndex);
+                return node.id || treeIndex;
+              }}
+              rowHeight={56}
+              canDrag={() => false}
+              canDrop={() => false}
+              generateNodeProps={({ node }: { node: RSTNode }) => ({
+                dataStore,
+                nodeStore: previewNodeStore,
+                activeNodeId,
+                previousNodeId: null,
+                onNodeContextMenu: ignoreContextMenu,
+                isContextMenuVisible: false,
+                buttons: buildPreviewNodeButtons(node, previewNodeStore),
+                zoomLevel: 1,
+              })}
+              nodeContentRenderer={(rendererProps: ConverseTekNodeRendererProps) => <ConverseTekNodeRenderer {...rendererProps} />}
+              reactVirtualizedListProps={{
+                width: treeWidth,
+              }}
+              slideRegionSize={100}
+            />
+          </ScalableScrollbar>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function createPreviewNodeStore(
+  conversationAsset: ConversationAssetType,
+  expansionByNodeId: Map<string, boolean>,
+  setActiveNodeId: (nodeId: string | null) => void,
+): PreviewNodeStore {
+  const nodeById = new Map<string, PromptNodeType | ElementNodeType>();
+  const promptNodeByIndex = new Map<number, PromptNodeType>();
+  const treeIndexByNodeId = new Map<string, number>();
+
+  conversationAsset.conversation.roots.forEach((root) => {
+    nodeById.set(getId(root), root);
+  });
+
+  conversationAsset.conversation.nodes.forEach((promptNode) => {
+    nodeById.set(getId(promptNode), promptNode);
+    promptNodeByIndex.set(promptNode.index, promptNode);
+
+    promptNode.branches.forEach((branch) => {
+      nodeById.set(getId(branch), branch);
+    });
+  });
+
+  const previewNodeStore: PreviewNodeStore = {
+    buildTreeData: () => [
+      {
+        title: conversationAsset.conversation.uiName || 'AI Draft Conversation',
+        id: '0',
+        type: 'core',
+        parentId: '-1',
+        children: conversationAsset.conversation.roots.map((root) => buildElementTreeNode(root, 'root', null, previewNodeStore)),
+        expanded: true,
+        canDrag: false,
+      },
+    ],
+    recordTreeIndex: (nodeId, treeIndex) => {
+      if (nodeId) treeIndexByNodeId.set(nodeId, treeIndex);
+    },
+    getNode: (nodeId) => {
+      if (!nodeId) return null;
+      return nodeById.get(nodeId) || null;
+    },
+    getPromptNodeByIndex: (index) => promptNodeByIndex.get(index) || null,
+    getTreeIndex: (nodeId) => treeIndexByNodeId.get(nodeId) ?? 0,
+    setActiveNode: () => setActiveNodeId(null),
+    initScrollToNode: () => undefined,
+    isNodeVisible: () => true,
+    setFocusedTreeNode: () => undefined,
+    getMaxTreeHorizontalNodePosition: () => 0,
+    setNodeExpansion: (nodeId, flag) => {
+      if (nodeId) expansionByNodeId.set(nodeId, flag);
+    },
+    isNodeExpanded: (nodeId) => {
+      if (!nodeId) return false;
+      return expansionByNodeId.get(nodeId) ?? true;
+    },
+  };
+
+  return previewNodeStore;
+}
+
+function buildElementTreeNode(
+  elementNode: ElementNodeType,
+  type: 'root' | 'response',
+  parentId: string | null,
+  previewNodeStore: PreviewNodeStore,
+): RSTNode {
+  const elementNodeId = getId(elementNode);
+
+  return {
+    title: elementNode.responseText,
+    subtitle: formatElementSubtitle(elementNode),
+    id: elementNodeId,
+    parentId,
+    type,
+    expanded: previewNodeStore.isNodeExpanded(elementNodeId),
+    canDrag: false,
+    children: buildElementChildren(elementNode, elementNodeId, previewNodeStore),
+  };
+}
+
+function buildElementChildren(elementNode: ElementNodeType, elementNodeId: string, previewNodeStore: PreviewNodeStore): RSTNode[] | null {
+  if (elementNode.nextNodeIndex === -1) return null;
+
+  if (elementNode.auxiliaryLink) {
+    const linkedPromptNode = previewNodeStore.getPromptNodeByIndex(elementNode.nextNodeIndex);
+    return [
+      {
+        title: `[Link to NODE ${elementNode.nextNodeIndex}]`,
+        id: `link-${elementNodeId}-${elementNode.nextNodeIndex}`,
+        type: 'link',
+        linkId: linkedPromptNode ? getId(linkedPromptNode) : null,
+        linkIndex: elementNode.nextNodeIndex,
+        canDrag: false,
+        parentId: elementNodeId,
+      },
+    ];
+  }
+
+  const childPromptNode = previewNodeStore.getPromptNodeByIndex(elementNode.nextNodeIndex);
+  if (!childPromptNode) return null;
+
+  return [buildPromptTreeNode(childPromptNode, elementNodeId, previewNodeStore)];
+}
+
+function buildPromptTreeNode(promptNode: PromptNodeType, parentId: string, previewNodeStore: PreviewNodeStore): RSTNode {
+  const promptNodeId = getId(promptNode);
+
+  return {
+    title: promptNode.text,
+    subtitle: formatPromptSubtitle(promptNode),
+    id: promptNodeId,
+    parentId,
+    type: 'node',
+    expanded: previewNodeStore.isNodeExpanded(promptNodeId),
+    canDrag: false,
+    children: promptNode.branches.map((branch) => buildElementTreeNode(branch, 'response', promptNodeId, previewNodeStore)),
+  };
+}
+
+function formatPromptSubtitle(promptNode: PromptNodeType): string {
+  return [
+    `NODE ${promptNode.index}`,
+    promptNode.comment ? `draft key ${promptNode.comment}` : '',
+    formatOperationCount('action', promptNode.actions?.ops),
+  ]
+    .filter(Boolean)
+    .join(' | ');
+}
+
+function formatElementSubtitle(elementNode: ElementNodeType): string {
+  const target = elementNode.nextNodeIndex === -1 ? 'END' : `${elementNode.auxiliaryLink ? 'link to' : 'to'} NODE ${elementNode.nextNodeIndex}`;
+
+  return [
+    target,
+    formatOperationCount('condition', elementNode.conditions?.ops),
+    formatOperationCount('action', elementNode.actions?.ops),
+  ]
+    .filter(Boolean)
+    .join(' | ');
+}
+
+function formatSpeaker(promptNode: PromptNodeType): string {
+  if (promptNode.speakerType === 'castId' && promptNode.sourceInSceneRef?.id) return promptNode.sourceInSceneRef.id;
+  if (promptNode.speakerType === 'speakerId' && promptNode.speakerOverrideId) return promptNode.speakerOverrideId;
+  return 'Narration';
+}
+
+function buildPreviewNodeButtons(node: RSTNode, previewNodeStore: PreviewNodeStore): JSX.Element[] {
+  if (node.type !== 'node') return [];
+
+  const promptNode = previewNodeStore.getNode(node.id);
+  if (promptNode == null || promptNode.type !== 'node') return [];
+
+  const speaker = formatSpeaker(promptNode);
+  const displaySpeaker = speaker.replace(/Default$/i, '') || speaker;
+
+  return [
+    <span
+      className="ai-draft-preview-tree__speaker-badge"
+      title={`${promptNode.speakerType || 'none'} ${speaker}`}
+    >
+      {displaySpeaker}
+    </span>,
+  ];
+}
+
+function formatOperationCount(label: string, operations: OperationCallType[] | null | undefined): string {
+  const operationCount = operations?.length || 0;
+  if (operationCount === 0) return '';
+
+  return `${operationCount} ${label}${operationCount === 1 ? '' : 's'}`;
+}

--- a/app/src/components/AiDraftModal/AiDraftModal.css
+++ b/app/src/components/AiDraftModal/AiDraftModal.css
@@ -171,11 +171,19 @@
   margin-left: 10px;
 }
 
+.ai-draft-personalities {
+  padding-top: 16px;
+}
+
 .ai-draft-personalities__toolbar {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
-  gap: 8px;
-  margin-bottom: 10px;
+  gap: 10px;
+  margin-bottom: 12px;
+}
+
+.ai-draft-personalities__toolbar .ant-btn {
+  min-width: 80px;
 }
 
 .ai-draft-personalities__toolbar .ant-btn,
@@ -187,16 +195,15 @@
 .ai-draft-personalities__list {
   display: flex;
   flex-direction: column;
-  gap: 8px;
   max-height: calc(100vh - 380px);
   min-height: 320px;
   overflow-y: auto;
-  padding: 2px;
+  padding: 2px 3px 2px 2px;
 }
 
 .ai-draft-personalities__empty,
 .ai-draft-personalities__editor-empty {
-  padding: 14px;
+  padding: 16px;
   background: #fafafa;
   color: #595959;
   box-shadow: inset 0 0 0 1px rgba(31, 47, 67, 0.1);
@@ -206,10 +213,9 @@
 .ai-draft-personalities__item {
   display: flex;
   flex-direction: column;
-  gap: 7px;
   width: 100%;
-  min-height: 72px;
-  padding: 10px;
+  min-height: 76px;
+  padding: 11px 12px;
   border: 0;
   border-radius: 4px;
   background: #fff;
@@ -220,6 +226,10 @@
   transition-property: background, box-shadow, opacity, transform;
   transition-duration: 140ms;
   transition-timing-function: cubic-bezier(0.2, 0, 0, 1);
+}
+
+.ai-draft-personalities__item + .ai-draft-personalities__item {
+  margin-top: 8px;
 }
 
 .ai-draft-personalities__item:hover,
@@ -246,8 +256,8 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
   min-width: 0;
+  margin-bottom: 8px;
   font-weight: 600;
 }
 
@@ -261,22 +271,35 @@
 .ai-draft-personalities__item-ids {
   display: flex;
   flex-wrap: wrap;
-  gap: 4px;
+  margin: -3px -5px -3px 0;
 }
 
 .ai-draft-personalities__item-ids .ant-tag,
 .ai-draft-personalities__item-header .ant-tag {
   max-width: 100%;
-  margin-right: 0;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.ai-draft-personalities__item-header .ant-tag {
+  flex: 0 0 auto;
+  margin-right: 0;
+  margin-left: 8px;
+}
+
+.ai-draft-personalities__item-ids .ant-tag {
+  margin: 3px 5px 3px 0;
 }
 
 .ai-draft-personalities__list-actions {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
-  margin-top: 10px;
+  margin-top: 12px;
+}
+
+.ai-draft-personalities__list-actions .ant-btn {
+  margin-right: 10px;
+  margin-bottom: 8px;
 }
 
 .ai-draft-personalities__editor {
@@ -288,19 +311,57 @@
   flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
-  gap: 10px;
-  min-height: 40px;
-  margin-bottom: 12px;
-  padding-bottom: 10px;
+  gap: 12px;
+  min-height: 42px;
+  margin-bottom: 16px;
+  padding-bottom: 12px;
   box-shadow: inset 0 -1px 0 rgba(31, 47, 67, 0.12);
 }
 
+.ai-draft-personalities__editor .ant-form-item {
+  margin-bottom: 18px;
+}
+
+.ai-draft-personalities__editor .ant-form-item:last-child {
+  margin-bottom: 0;
+}
+
+.ai-draft-personalities__editor .ant-form-item-label {
+  padding-bottom: 4px;
+}
+
 .ai-draft-personalities__editor .ant-select-selection--multiple {
-  min-height: 40px;
+  min-height: 34px;
+  padding-bottom: 2px;
+}
+
+.ai-draft-personalities__editor .ant-select-selection--multiple .ant-select-selection__rendered {
+  min-height: 30px;
+  margin-right: 6px;
+  margin-bottom: -2px;
+  margin-left: 6px;
+  line-height: 30px;
 }
 
 .ai-draft-personalities__editor .ant-select-selection__choice {
   max-width: 100%;
+}
+
+.ai-draft-personalities__editor .ant-select-selection--multiple .ant-select-selection__choice {
+  height: 24px;
+  margin-right: 5px;
+  margin-top: 4px;
+  line-height: 22px;
+}
+
+.ai-draft-personalities__editor .ant-select-selection--multiple .ant-select-search--inline {
+  height: 28px;
+  line-height: 28px;
+}
+
+.ai-draft-personalities__editor .ant-select-selection--multiple .ant-select-search__field {
+  height: 24px;
+  margin-top: 3px;
 }
 
 .ai-draft-preview {

--- a/app/src/components/AiDraftModal/AiDraftModal.css
+++ b/app/src/components/AiDraftModal/AiDraftModal.css
@@ -1,0 +1,414 @@
+.ai-draft-modal {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  max-height: calc(100vh - 190px);
+  overflow-y: auto;
+  padding-right: 4px;
+  padding-bottom: 4px;
+}
+
+.ai-draft-modal textarea,
+.ai-draft-modal input {
+  font-family: inherit;
+}
+
+.ai-draft-modal .ant-form-item-label label {
+  color: #262626;
+  font-weight: 600;
+}
+
+.ai-draft-modal .ant-input,
+.ai-draft-modal .ant-select-selection {
+  border-color: #5f6b7a;
+}
+
+.ai-draft-modal .ant-input::-webkit-input-placeholder {
+  color: #c8d1dc;
+  opacity: 1;
+}
+
+.ai-draft-modal .ant-input::placeholder {
+  color: #c8d1dc;
+  opacity: 1;
+}
+
+.ai-draft-modal__field-label {
+  display: inline-flex;
+  align-items: center;
+  max-width: 100%;
+}
+
+.ai-draft-modal__help-icon {
+  margin-left: 6px;
+  padding: 4px;
+  color: #59728a;
+  cursor: help;
+  line-height: 1;
+}
+
+.ai-draft-modal__help-icon:hover,
+.ai-draft-modal__help-icon:focus {
+  color: #1f5f8b;
+}
+
+.ai-draft-modal__model-row {
+  display: flex;
+  align-items: center;
+}
+
+.ai-draft-modal__model-row .ant-select {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.ai-draft-modal__model-row .ant-btn {
+  flex: 0 0 auto;
+  margin-left: 8px;
+  min-height: 32px;
+}
+
+.ai-draft-modal__inline-alert {
+  margin-top: 8px;
+}
+
+.ai-draft-modal__field-note {
+  margin-top: 6px;
+  color: #595959;
+  font-size: 12px;
+}
+
+.ai-draft-modal__field-actions {
+  display: flex;
+  margin-top: 8px;
+}
+
+.ai-draft-modal__field-actions .ant-btn {
+  min-height: 32px;
+}
+
+.ai-draft-modal__alert {
+  margin-bottom: 12px;
+  white-space: pre-line;
+}
+
+.ai-draft-modal__meta {
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+  border: 1px solid #d9d9d9;
+  background: #fafafa;
+}
+
+.ai-draft-modal__meta > div {
+  display: grid;
+  grid-template-columns: 88px minmax(0, 1fr);
+  align-items: start;
+  gap: 8px;
+}
+
+.ai-draft-modal__meta span {
+  color: #595959;
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 24px;
+  text-transform: uppercase;
+}
+
+.ai-draft-modal__meta code {
+  display: block;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  padding: 4px 6px;
+  border: 1px solid #e8e8e8;
+  background: #fff;
+  color: #262626;
+  font-size: 12px;
+}
+
+.ai-draft-modal__artifact-actions {
+  padding-top: 4px;
+}
+
+.ai-draft-modal__artifact-actions > div {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.ai-draft-modal__artifact-actions .ant-btn {
+  min-height: 28px;
+}
+
+.ai-draft-modal__actions {
+  display: flex;
+  flex-wrap: wrap;
+  margin: 8px 0 12px;
+}
+
+.ai-draft-modal__actions .ant-btn {
+  margin-right: 8px;
+  margin-bottom: 8px;
+  min-height: 32px;
+}
+
+.ai-draft-modal__actions .ant-btn:last-child {
+  margin-right: 0;
+}
+
+.ai-draft-modal__loading {
+  display: flex;
+  align-items: center;
+  padding: 10px 0;
+  color: #595959;
+}
+
+.ai-draft-modal__loading span {
+  margin-left: 10px;
+}
+
+.ai-draft-preview {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  margin-top: 8px;
+}
+
+.ai-draft-preview__summary {
+  padding: 12px 0;
+  border-top: 1px solid #e8e8e8;
+  border-bottom: 1px solid #e8e8e8;
+}
+
+.ai-draft-preview__summary h3 {
+  color: #262626;
+  margin: 0 0 6px;
+}
+
+.ai-draft-preview__summary p,
+.ai-draft-preview__suggestion p {
+  margin: 0;
+  white-space: pre-wrap;
+}
+
+.ai-draft-preview__cast {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.ai-draft-preview__suggestion {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+  border: 1px solid #d9d9d9;
+  background: #fff;
+}
+
+.ai-draft-preview__suggestion h4 {
+  margin: 0;
+  color: #262626;
+}
+
+.ai-draft-preview-tree {
+  display: flex;
+  flex-direction: column;
+  min-height: 520px;
+  border: 1px solid #d9d9d9;
+  background: #2f2f2f;
+}
+
+.ai-draft-preview-tree__toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  min-height: 36px;
+  padding: 0 12px;
+  border-bottom: 1px solid #e8e8e8;
+  background: #fafafa;
+  color: #595959;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.ai-draft-preview-tree__toolbar .anticon {
+  margin-right: 6px;
+}
+
+.ai-draft-preview-tree__canvas {
+  position: relative;
+  height: 484px;
+  min-width: 0;
+  overflow: hidden;
+  background: #2f2f2f;
+}
+
+/* Keep these tree overrides scoped to the AI preview. The real DialogEditor tree uses the same renderer classes. */
+.ai-draft-preview-tree__canvas .rst__rowWrapper {
+  padding-top: 7px;
+  padding-bottom: 7px;
+}
+
+.ai-draft-preview-tree__canvas .rst__row {
+  align-items: stretch;
+}
+
+.ai-draft-preview-tree__canvas .rst__rowContents {
+  align-items: flex-start;
+  flex: 0 1 auto;
+  width: auto;
+  min-width: 280px;
+  max-width: 540px;
+  height: auto;
+  min-height: 42px;
+  padding: 6px 10px;
+  box-shadow: 0 2px 7px rgba(0, 0, 0, 0.28);
+}
+
+.ai-draft-preview-tree__canvas .node-renderer__row-contents section {
+  display: flex;
+  align-items: flex-start;
+  width: 100%;
+  min-width: 0;
+}
+
+.ai-draft-preview-tree__canvas .node-renderer__row-contents-logic {
+  flex: 0 0 auto;
+  padding-top: 1px;
+}
+
+.ai-draft-preview-tree__canvas .rst__rowLabel {
+  flex: 1 1 auto;
+  min-width: 0;
+  padding-right: 0;
+}
+
+.ai-draft-preview-tree__canvas .rst__rowTitle,
+.ai-draft-preview-tree__canvas .rst__rowSubtitle {
+  max-width: 100%;
+  white-space: normal;
+  overflow-wrap: anywhere;
+}
+
+.ai-draft-preview-tree__canvas .rst__rowTitle {
+  line-height: 1.25;
+}
+
+.ai-draft-preview-tree__canvas .rst__rowTitleWithSubtitle {
+  display: block;
+  height: auto;
+  margin-bottom: 2px;
+  font-size: 12px;
+}
+
+.ai-draft-preview-tree__canvas .rst__rowSubtitle {
+  display: block;
+  color: #595959;
+  font-size: 10px;
+  line-height: 1.25;
+}
+
+.ai-draft-preview-tree__canvas .node-renderer__response-row-contents .rst__rowSubtitle {
+  color: #e8e8e8;
+}
+
+.ai-draft-preview-tree__canvas .rst__rowToolbar {
+  flex: 0 0 auto;
+  margin-left: 10px;
+}
+
+.ai-draft-preview-tree__speaker-badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 20px;
+  max-width: 130px;
+  overflow: hidden;
+  padding: 0 7px;
+  border-radius: 3px;
+  background: #003a8c;
+  color: #fff;
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 20px;
+  text-overflow: ellipsis;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.ai-draft-preview-tree__canvas .node-renderer__response-row-contents .ai-draft-preview-tree__speaker-badge {
+  background: #262626;
+}
+
+.ai-draft-preview-tree__canvas .rst__moveHandle {
+  flex: 0 0 44px;
+}
+
+.ai-draft-preview-tree__canvas .node-renderer__row {
+  box-shadow: none !important;
+}
+
+.ai-draft-preview-tree__canvas .rst__rowContents {
+  cursor: default;
+}
+
+.ai-draft-preview-tree__canvas .rst__moveHandle {
+  cursor: default;
+}
+
+.ai-draft-preview-tree__canvas .ReactVirtualized__Grid {
+  background: #2f2f2f;
+  outline: none;
+}
+
+.ai-draft-artifact-viewer {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-height: calc(100vh - 240px);
+}
+
+.ai-draft-artifact-viewer__path {
+  overflow-wrap: anywhere;
+  padding: 6px 8px;
+  border: 1px solid #e8e8e8;
+  background: #fafafa;
+  color: #595959;
+  font-family: Consolas, 'Courier New', monospace;
+  font-size: 12px;
+}
+
+.ai-draft-artifact-viewer__toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+  color: #595959;
+  font-size: 12px;
+}
+
+.ai-draft-artifact-viewer__toolbar .ant-btn {
+  min-height: 26px;
+}
+
+.ai-draft-artifact-viewer__alert {
+  margin-bottom: 0;
+}
+
+.ai-draft-artifact-viewer pre {
+  min-height: 360px;
+  max-height: calc(100vh - 330px);
+  margin: 0;
+  overflow: auto;
+  padding: 12px;
+  border: 1px solid #d9d9d9;
+  background: #1f1f1f;
+  color: #e8e8e8;
+  font-family: Consolas, 'Courier New', monospace;
+  font-size: 12px;
+  line-height: 1.45;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  user-select: text;
+}

--- a/app/src/components/AiDraftModal/AiDraftModal.css
+++ b/app/src/components/AiDraftModal/AiDraftModal.css
@@ -2,10 +2,14 @@
   display: flex;
   flex-direction: column;
   gap: 14px;
-  max-height: calc(100vh - 190px);
+  max-height: calc(100vh - 170px);
   overflow-y: auto;
   padding-right: 4px;
   padding-bottom: 4px;
+}
+
+.ai-draft-modal--has-draft {
+  max-height: calc(100vh - 150px);
 }
 
 .ai-draft-modal textarea,
@@ -214,9 +218,11 @@
 .ai-draft-preview-tree {
   display: flex;
   flex-direction: column;
-  min-height: 520px;
-  border: 1px solid #d9d9d9;
-  background: #2f2f2f;
+  min-height: 480px;
+  overflow: hidden;
+  border-radius: 4px;
+  background: #f3f6fa;
+  box-shadow: 0 0 0 1px rgba(31, 47, 67, 0.12), 0 10px 24px rgba(31, 47, 67, 0.12);
 }
 
 .ai-draft-preview-tree__toolbar {
@@ -225,12 +231,12 @@
   align-items: center;
   min-height: 36px;
   padding: 0 12px;
-  border-bottom: 1px solid #e8e8e8;
-  background: #fafafa;
-  color: #595959;
+  background: #fff;
+  color: #4b6178;
   font-size: 12px;
   font-weight: 600;
   text-transform: uppercase;
+  box-shadow: 0 1px 0 rgba(31, 47, 67, 0.12);
 }
 
 .ai-draft-preview-tree__toolbar .anticon {
@@ -239,32 +245,45 @@
 
 .ai-draft-preview-tree__canvas {
   position: relative;
-  height: 484px;
+  height: calc(100vh - 430px);
+  min-height: 400px;
+  max-height: 620px;
   min-width: 0;
   overflow: hidden;
-  background: #2f2f2f;
+  background: #f3f6fa;
 }
 
 /* Keep these tree overrides scoped to the AI preview. The real DialogEditor tree uses the same renderer classes. */
+.ai-draft-preview-tree__canvas .rst__lineHalfHorizontalRight::before,
+.ai-draft-preview-tree__canvas .rst__lineFullVertical::after,
+.ai-draft-preview-tree__canvas .rst__lineHalfVerticalTop::after,
+.ai-draft-preview-tree__canvas .rst__lineHalfVerticalBottom::after,
+.ai-draft-preview-tree__canvas .rst__lineChildren::after {
+  background-color: #9cadbf;
+}
+
 .ai-draft-preview-tree__canvas .rst__rowWrapper {
-  padding-top: 7px;
-  padding-bottom: 7px;
+  padding-top: 8px;
+  padding-bottom: 8px;
 }
 
 .ai-draft-preview-tree__canvas .rst__row {
   align-items: stretch;
+  white-space: normal;
 }
 
 .ai-draft-preview-tree__canvas .rst__rowContents {
   align-items: flex-start;
   flex: 0 1 auto;
   width: auto;
-  min-width: 280px;
-  max-width: 540px;
+  min-width: 340px;
+  max-width: 760px;
   height: auto;
-  min-height: 42px;
-  padding: 6px 10px;
-  box-shadow: 0 2px 7px rgba(0, 0, 0, 0.28);
+  min-height: 40px;
+  padding: 7px 10px;
+  border: 0;
+  border-radius: 4px;
+  box-shadow: 0 0 0 1px rgba(31, 47, 67, 0.12), 0 3px 10px rgba(31, 47, 67, 0.14);
 }
 
 .ai-draft-preview-tree__canvas .node-renderer__row-contents section {
@@ -277,6 +296,10 @@
 .ai-draft-preview-tree__canvas .node-renderer__row-contents-logic {
   flex: 0 0 auto;
   padding-top: 1px;
+}
+
+.ai-draft-preview-tree__canvas .node-renderer__row-contents-logic .anticon {
+  font-size: 15px !important;
 }
 
 .ai-draft-preview-tree__canvas .rst__rowLabel {
@@ -293,7 +316,8 @@
 }
 
 .ai-draft-preview-tree__canvas .rst__rowTitle {
-  line-height: 1.25;
+  line-height: 1.35;
+  text-wrap: pretty;
 }
 
 .ai-draft-preview-tree__canvas .rst__rowTitleWithSubtitle {
@@ -311,7 +335,7 @@
 }
 
 .ai-draft-preview-tree__canvas .node-renderer__response-row-contents .rst__rowSubtitle {
-  color: #e8e8e8;
+  color: #d8e1ec;
 }
 
 .ai-draft-preview-tree__canvas .rst__rowToolbar {
@@ -323,7 +347,7 @@
   display: inline-flex;
   align-items: center;
   min-height: 20px;
-  max-width: 130px;
+  max-width: 150px;
   overflow: hidden;
   padding: 0 7px;
   border-radius: 3px;
@@ -338,11 +362,15 @@
 }
 
 .ai-draft-preview-tree__canvas .node-renderer__response-row-contents .ai-draft-preview-tree__speaker-badge {
-  background: #262626;
+  background: #243447;
 }
 
 .ai-draft-preview-tree__canvas .rst__moveHandle {
-  flex: 0 0 44px;
+  flex: 0 0 34px;
+  width: 34px;
+  border: 0;
+  border-radius: 4px 0 0 4px;
+  box-shadow: 0 0 0 1px rgba(31, 47, 67, 0.12), 0 3px 10px rgba(31, 47, 67, 0.12);
 }
 
 .ai-draft-preview-tree__canvas .node-renderer__row {
@@ -358,8 +386,17 @@
 }
 
 .ai-draft-preview-tree__canvas .ReactVirtualized__Grid {
-  background: #2f2f2f;
+  background: #f3f6fa;
   outline: none;
+}
+
+.ai-draft-preview-tree__canvas .ReactVirtualized__Grid__innerScrollContainer {
+  padding-bottom: 36px;
+}
+
+.ai-draft-preview-tree__canvas .rst__collapseButton,
+.ai-draft-preview-tree__canvas .rst__expandButton {
+  box-shadow: 0 0 0 1px #7f91a5, 0 2px 4px rgba(31, 47, 67, 0.18);
 }
 
 .ai-draft-artifact-viewer {

--- a/app/src/components/AiDraftModal/AiDraftModal.css
+++ b/app/src/components/AiDraftModal/AiDraftModal.css
@@ -171,6 +171,138 @@
   margin-left: 10px;
 }
 
+.ai-draft-personalities__toolbar {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
+.ai-draft-personalities__toolbar .ant-btn,
+.ai-draft-personalities__list-actions .ant-btn,
+.ai-draft-personalities__editor-heading .ant-btn {
+  min-height: 32px;
+}
+
+.ai-draft-personalities__list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-height: calc(100vh - 380px);
+  min-height: 320px;
+  overflow-y: auto;
+  padding: 2px;
+}
+
+.ai-draft-personalities__empty,
+.ai-draft-personalities__editor-empty {
+  padding: 14px;
+  background: #fafafa;
+  color: #595959;
+  box-shadow: inset 0 0 0 1px rgba(31, 47, 67, 0.1);
+  text-wrap: pretty;
+}
+
+.ai-draft-personalities__item {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  width: 100%;
+  min-height: 72px;
+  padding: 10px;
+  border: 0;
+  border-radius: 4px;
+  background: #fff;
+  box-shadow: 0 0 0 1px rgba(31, 47, 67, 0.12), 0 2px 8px rgba(31, 47, 67, 0.08);
+  color: #262626;
+  cursor: pointer;
+  text-align: left;
+  transition-property: background, box-shadow, opacity, transform;
+  transition-duration: 140ms;
+  transition-timing-function: cubic-bezier(0.2, 0, 0, 1);
+}
+
+.ai-draft-personalities__item:hover,
+.ai-draft-personalities__item:focus {
+  outline: none;
+  background: #f6f8fb;
+  box-shadow: 0 0 0 1px rgba(31, 95, 139, 0.3), 0 4px 12px rgba(31, 47, 67, 0.12);
+}
+
+.ai-draft-personalities__item:active {
+  transform: scale(0.96);
+}
+
+.ai-draft-personalities__item--active {
+  background: #eef6fb;
+  box-shadow: 0 0 0 2px rgba(31, 95, 139, 0.34), 0 4px 12px rgba(31, 47, 67, 0.14);
+}
+
+.ai-draft-personalities__item--disabled {
+  opacity: 0.58;
+}
+
+.ai-draft-personalities__item-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  min-width: 0;
+  font-weight: 600;
+}
+
+.ai-draft-personalities__item-header > span:first-child {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ai-draft-personalities__item-ids {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.ai-draft-personalities__item-ids .ant-tag,
+.ai-draft-personalities__item-header .ant-tag {
+  max-width: 100%;
+  margin-right: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.ai-draft-personalities__list-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.ai-draft-personalities__editor {
+  min-height: 320px;
+}
+
+.ai-draft-personalities__editor-heading {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  min-height: 40px;
+  margin-bottom: 12px;
+  padding-bottom: 10px;
+  box-shadow: inset 0 -1px 0 rgba(31, 47, 67, 0.12);
+}
+
+.ai-draft-personalities__editor .ant-select-selection--multiple {
+  min-height: 40px;
+}
+
+.ai-draft-personalities__editor .ant-select-selection__choice {
+  max-width: 100%;
+}
+
 .ai-draft-preview {
   display: flex;
   flex-direction: column;

--- a/app/src/components/AiDraftModal/AiDraftModal.css
+++ b/app/src/components/AiDraftModal/AiDraftModal.css
@@ -402,7 +402,7 @@
 .ai-draft-artifact-viewer {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 12px;
   max-height: calc(100vh - 240px);
 }
 
@@ -419,14 +419,33 @@
 .ai-draft-artifact-viewer__toolbar {
   display: flex;
   flex-wrap: wrap;
-  align-items: center;
-  gap: 10px;
+  align-items: flex-start;
+  gap: 8px 16px;
+  padding-top: 2px;
   color: #595959;
   font-size: 12px;
 }
 
+.ai-draft-artifact-viewer__toolbar .ant-btn-group {
+  flex: 0 0 auto;
+}
+
 .ai-draft-artifact-viewer__toolbar .ant-btn {
-  min-height: 26px;
+  min-height: 30px;
+  padding-right: 12px;
+  padding-left: 12px;
+}
+
+.ai-draft-artifact-viewer__note {
+  flex: 1 0 100%;
+  min-width: 0;
+  padding: 8px 10px;
+  border-radius: 3px;
+  background: #f6f8fb;
+  box-shadow: inset 0 0 0 1px rgba(31, 47, 67, 0.08);
+  color: #5f6b7a;
+  line-height: 1.4;
+  text-wrap: pretty;
 }
 
 .ai-draft-artifact-viewer__alert {

--- a/app/src/components/AiDraftModal/AiDraftModal.tsx
+++ b/app/src/components/AiDraftModal/AiDraftModal.tsx
@@ -2,7 +2,7 @@ import React, { ChangeEvent, useEffect, useMemo, useState } from 'react';
 import { toJS } from 'mobx';
 import { runInAction } from 'mobx';
 import { observer } from 'mobx-react';
-import { Alert, Button, Col, Form, Icon, Input, message, Row, Select, Spin, Tabs, Tag, Tooltip } from 'antd';
+import { Alert, Button, Checkbox, Col, Form, Icon, Input, message, Row, Select, Spin, Tabs, Tag, Tooltip } from 'antd';
 import classnames from 'classnames';
 
 import { useStore } from 'hooks/useStore';
@@ -22,13 +22,7 @@ import {
   saveAiWorkspaceSettings,
   validateConversationRoundTrip,
 } from 'services/api';
-import {
-  addNodes,
-  getId,
-  updatePromptNode,
-  updateResponseNode,
-  updateRootNode,
-} from 'utils/conversation-utils';
+import { addNodes, getId, updatePromptNode, updateResponseNode, updateRootNode } from 'utils/conversation-utils';
 import {
   buildAcceptedDraft,
   buildPreviewConversationAssetFromDraft,
@@ -37,6 +31,7 @@ import {
   validateAiDraft,
 } from 'utils/ai-draft-utils';
 import {
+  AiCastPersonalityType,
   AiConversationDraftType,
   AiDraftModeType,
   AiDraftRunResultType,
@@ -70,6 +65,7 @@ const emptySettings: AiSettingsType = {
   timeoutSeconds: 300,
   modelCatalogs: {},
   workspaces: {},
+  defaultCastPersonalities: [],
 };
 
 type ProviderUi = {
@@ -133,13 +129,75 @@ function normaliseWorkspaceKey(path: string): string {
   return path.replaceAll('\\', '/').replace(/\/+$/g, '').toLowerCase();
 }
 
-function createWorkspaceSettings(workingDirectory: string): AiWorkspaceSettingsType {
+function createWorkspaceSettings(workingDirectory: string, defaultPersonalities: AiCastPersonalityType[] = []): AiWorkspaceSettingsType {
   return {
     workingDirectory,
     contextPaths: [],
     houseStyleNotes: '',
     defaultCampaignBrief: '',
+    castPersonalities: cloneDefaultCastPersonalities(defaultPersonalities),
   };
+}
+
+function cloneDefaultCastPersonalities(defaultPersonalities: AiCastPersonalityType[]): AiCastPersonalityType[] {
+  return defaultPersonalities.map((personality) => ({
+    ...personality,
+    castIds: [...personality.castIds],
+    speakerIds: [...personality.speakerIds],
+  }));
+}
+
+function makePersonalityId(prefix = 'custom'): string {
+  return `${prefix}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function createCustomCastPersonality(): AiCastPersonalityType {
+  return {
+    id: makePersonalityId(),
+    label: 'New personality',
+    castIds: [],
+    speakerIds: [],
+    rules: '',
+    enabled: true,
+    defaultKey: '',
+  };
+}
+
+function cloneCastPersonality(personality: AiCastPersonalityType): AiCastPersonalityType {
+  return {
+    ...personality,
+    id: makePersonalityId('copy'),
+    label: `${personality.label || 'Personality'} Copy`,
+    castIds: [...personality.castIds],
+    speakerIds: [...personality.speakerIds],
+    defaultKey: '',
+  };
+}
+
+function normaliseIdTags(values: string[]): string[] {
+  const seenValues = new Set<string>();
+  const normalisedValues: string[] = [];
+
+  values
+    .map((value) => value.trim())
+    .filter(Boolean)
+    .forEach((value) => {
+      const key = value.toLowerCase();
+      if (seenValues.has(key)) return;
+      seenValues.add(key);
+      normalisedValues.push(value);
+    });
+
+  return normalisedValues;
+}
+
+function matchesPersonalitySearch(personality: AiCastPersonalityType, searchTerm: string): boolean {
+  const trimmedSearchTerm = searchTerm.trim().toLowerCase();
+  if (trimmedSearchTerm === '') return true;
+
+  return [personality.label, personality.defaultKey, ...personality.castIds, ...personality.speakerIds]
+    .filter(Boolean)
+    .some((value) => value.toLowerCase().includes(trimmedSearchTerm));
 }
 
 function AiDraftModal({ globalModalId, mode, selectedNodeId }: Props) {
@@ -157,6 +215,8 @@ function AiDraftModal({ globalModalId, mode, selectedNodeId }: Props) {
   const [diagnosticsPath, setDiagnosticsPath] = useState('');
   const [draftRunResult, setDraftRunResult] = useState<AiDraftRunResultType | null>(null);
   const [activeTab, setActiveTab] = useState('draft');
+  const [personalitySearch, setPersonalitySearch] = useState('');
+  const [selectedPersonalityId, setSelectedPersonalityId] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [isLoadingModels, setIsLoadingModels] = useState(false);
   const [isSavingConfiguration, setIsSavingConfiguration] = useState(false);
@@ -169,6 +229,18 @@ function AiDraftModal({ globalModalId, mode, selectedNodeId }: Props) {
   }, [selectedNodeId, nodeStore.activeNode]);
   const providerName = settings.selectedProvider || 'codex';
   const providerUi = getProviderUi(providerName);
+  const castPersonalities = workspaceSettings?.castPersonalities || [];
+  const filteredCastPersonalities = useMemo(
+    () => castPersonalities.filter((personality) => matchesPersonalitySearch(personality, personalitySearch)),
+    [castPersonalities, personalitySearch],
+  );
+  const selectedPersonality = useMemo(
+    () => castPersonalities.find((personality) => personality.id === selectedPersonalityId) || castPersonalities[0] || null,
+    [castPersonalities, selectedPersonalityId],
+  );
+  const selectedDefaultPersonality = selectedPersonality?.defaultKey
+    ? settings.defaultCastPersonalities.find((personality) => personality.defaultKey === selectedPersonality.defaultKey)
+    : null;
 
   const canGenerate = workingDirectory != null && (mode === 'fullConversation' || selectedNode != null);
   const canAccept = draft != null && validation.errors.length === 0;
@@ -246,7 +318,7 @@ function AiDraftModal({ globalModalId, mode, selectedNodeId }: Props) {
 
       if (workingDirectory) {
         const key = normaliseWorkspaceKey(workingDirectory);
-        setWorkspaceSettings(loadedSettings.workspaces[key] || createWorkspaceSettings(workingDirectory));
+        setWorkspaceSettings(loadedSettings.workspaces[key] || createWorkspaceSettings(workingDirectory, loadedSettings.defaultCastPersonalities));
       }
 
       if (refreshModelsForSettingsTab && activeTab === 'settings') {
@@ -273,6 +345,12 @@ function AiDraftModal({ globalModalId, mode, selectedNodeId }: Props) {
     setValidation(validateAiDraft(draft, defStore.operations, mode, selectedNode));
   }, [draft, mode, selectedNode, defStore.operations]);
 
+  useEffect(() => {
+    if (workspaceSettings == null) return;
+    if (workspaceSettings.castPersonalities.some((personality) => personality.id === selectedPersonalityId)) return;
+    setSelectedPersonalityId(workspaceSettings.castPersonalities[0]?.id || '');
+  }, [workspaceSettings, selectedPersonalityId]);
+
   const updateSettings = (patch: Partial<AiSettingsType>) => {
     console.log(`${AI_DEBUG_PREFIX} updateSettings`, {
       patch,
@@ -288,9 +366,78 @@ function AiDraftModal({ globalModalId, mode, selectedNodeId }: Props) {
 
   const updateWorkspaceSettings = (patch: Partial<AiWorkspaceSettingsType>) => {
     setWorkspaceSettings((previousSettings) => ({
-      ...(previousSettings || createWorkspaceSettings(workingDirectory || '')),
+      ...(previousSettings || createWorkspaceSettings(workingDirectory || '', settings.defaultCastPersonalities)),
       ...patch,
     }));
+  };
+
+  const updateCastPersonalities = (nextPersonalities: AiCastPersonalityType[]) => {
+    updateWorkspaceSettings({ castPersonalities: nextPersonalities });
+  };
+
+  const updateSelectedPersonality = (patch: Partial<AiCastPersonalityType>) => {
+    if (selectedPersonality == null) return;
+
+    updateCastPersonalities(
+      castPersonalities.map((personality) =>
+        personality.id === selectedPersonality.id
+          ? {
+              ...personality,
+              ...patch,
+            }
+          : personality,
+      ),
+    );
+  };
+
+  const addCastPersonality = () => {
+    const personality = createCustomCastPersonality();
+    updateCastPersonalities([...castPersonalities, personality]);
+    setSelectedPersonalityId(personality.id);
+  };
+
+  const duplicateSelectedPersonality = () => {
+    if (selectedPersonality == null) return;
+
+    const personality = cloneCastPersonality(selectedPersonality);
+    updateCastPersonalities([...castPersonalities, personality]);
+    setSelectedPersonalityId(personality.id);
+  };
+
+  const deleteSelectedPersonality = () => {
+    if (selectedPersonality == null) return;
+
+    const nextPersonalities = castPersonalities.filter((personality) => personality.id !== selectedPersonality.id);
+    updateCastPersonalities(nextPersonalities);
+    setSelectedPersonalityId(nextPersonalities[0]?.id || '');
+  };
+
+  const restoreSelectedDefaultPersonality = () => {
+    if (selectedPersonality == null || selectedDefaultPersonality == null) return;
+
+    updateSelectedPersonality({
+      label: selectedDefaultPersonality.label,
+      castIds: [...selectedDefaultPersonality.castIds],
+      speakerIds: [...selectedDefaultPersonality.speakerIds],
+      rules: selectedDefaultPersonality.rules,
+      enabled: selectedDefaultPersonality.enabled,
+      defaultKey: selectedDefaultPersonality.defaultKey,
+    });
+  };
+
+  const restoreMissingDefaultPersonalities = () => {
+    const existingDefaultKeys = new Set(castPersonalities.map((personality) => personality.defaultKey).filter(Boolean));
+    const missingDefaults = cloneDefaultCastPersonalities(settings.defaultCastPersonalities).filter(
+      (personality) => !existingDefaultKeys.has(personality.defaultKey),
+    );
+
+    if (missingDefaults.length === 0) {
+      void message.info('All default cast personalities are already present.');
+      return;
+    }
+
+    updateCastPersonalities([...castPersonalities, ...missingDefaults]);
+    setSelectedPersonalityId(missingDefaults[0].id);
   };
 
   const addContextPath = (path: string) => {
@@ -386,9 +533,9 @@ function AiDraftModal({ globalModalId, mode, selectedNodeId }: Props) {
   };
 
   useEffect(() => {
-    const isSettingsTab = activeTab === 'settings';
+    const isConfigurationTab = activeTab === 'settings' || activeTab === 'cast-personalities';
 
-    modalStore.setShowOkButton(isSettingsTab, globalModalId);
+    modalStore.setShowOkButton(isConfigurationTab, globalModalId);
     modalStore.setOkLabel('Save AI Settings', globalModalId);
     modalStore.setDisableOk(isSavingConfiguration, globalModalId);
     modalStore.setIsLoading(isSavingConfiguration, globalModalId);
@@ -651,13 +798,7 @@ function AiDraftModal({ globalModalId, mode, selectedNodeId }: Props) {
           )}
 
           {draft && (
-            <DraftPreview
-              draft={draft}
-              validation={validation}
-              mode={mode}
-              workingDirectory={workingDirectory || ''}
-              selectedNode={selectedNode}
-            />
+            <DraftPreview draft={draft} validation={validation} mode={mode} workingDirectory={workingDirectory || ''} selectedNode={selectedNode} />
           )}
         </TabPane>
 
@@ -701,7 +842,10 @@ function AiDraftModal({ globalModalId, mode, selectedNodeId }: Props) {
                 </Form.Item>
                 <Form.Item
                   label={
-                    <FieldLabel label={providerUi.modelLabel} help="Fetched from the provider CLI. Leave as provider default/latest to avoid pinning to a specific model." />
+                    <FieldLabel
+                      label={providerUi.modelLabel}
+                      help="Fetched from the provider CLI. Leave as provider default/latest to avoid pinning to a specific model."
+                    />
                   }
                 >
                   <div className="ai-draft-modal__model-row">
@@ -737,7 +881,11 @@ function AiDraftModal({ globalModalId, mode, selectedNodeId }: Props) {
                     </Tooltip>
                   </div>
                   {modelCatalog && modelCatalog.error && (
-                    <Alert className="ai-draft-modal__inline-alert" type="warning" message={modelCatalog.error || 'Could not load provider models.'} />
+                    <Alert
+                      className="ai-draft-modal__inline-alert"
+                      type="warning"
+                      message={modelCatalog.error || 'Could not load provider models.'}
+                    />
                   )}
                   {modelCatalog?.success && (
                     <div className="ai-draft-modal__field-note">
@@ -839,6 +987,143 @@ function AiDraftModal({ globalModalId, mode, selectedNodeId }: Props) {
             </Col>
           </Row>
         </TabPane>
+
+        <TabPane tab="Cast Personalities" key="cast-personalities">
+          <Row gutter={16}>
+            <Col md={9}>
+              <div className="ai-draft-personalities__toolbar">
+                <Input
+                  value={personalitySearch}
+                  prefix={<Icon type="search" />}
+                  placeholder="Search personalities"
+                  onChange={(event) => setPersonalitySearch(event.target.value)}
+                />
+                <Button icon="plus" onClick={addCastPersonality}>
+                  Add
+                </Button>
+              </div>
+
+              <div className="ai-draft-personalities__list">
+                {filteredCastPersonalities.length === 0 ? (
+                  <div className="ai-draft-personalities__empty">No matching personalities.</div>
+                ) : (
+                  filteredCastPersonalities.map((personality) => (
+                    <button
+                      key={personality.id}
+                      type="button"
+                      className={classnames('ai-draft-personalities__item', {
+                        'ai-draft-personalities__item--active': selectedPersonality?.id === personality.id,
+                        'ai-draft-personalities__item--disabled': !personality.enabled,
+                      })}
+                      onClick={() => setSelectedPersonalityId(personality.id)}
+                    >
+                      <span className="ai-draft-personalities__item-header">
+                        <span>{personality.label || 'Untitled personality'}</span>
+                        {personality.defaultKey && <Tag>Default</Tag>}
+                      </span>
+                      <span className="ai-draft-personalities__item-ids">
+                        {[...personality.castIds, ...personality.speakerIds].slice(0, 4).map((id) => (
+                          <Tag key={id}>{id}</Tag>
+                        ))}
+                        {personality.castIds.length + personality.speakerIds.length > 4 && (
+                          <Tag>+{personality.castIds.length + personality.speakerIds.length - 4}</Tag>
+                        )}
+                      </span>
+                    </button>
+                  ))
+                )}
+              </div>
+
+              <div className="ai-draft-personalities__list-actions">
+                <Button icon="copy" disabled={selectedPersonality == null} onClick={duplicateSelectedPersonality}>
+                  Duplicate
+                </Button>
+                <Button icon="delete" disabled={selectedPersonality == null} onClick={deleteSelectedPersonality}>
+                  Delete
+                </Button>
+                <Button icon="reload" onClick={restoreMissingDefaultPersonalities}>
+                  Restore Missing Defaults
+                </Button>
+              </div>
+            </Col>
+
+            <Col md={15}>
+              {selectedPersonality == null ? (
+                <div className="ai-draft-personalities__editor-empty">Add a personality or restore the defaults to start.</div>
+              ) : (
+                <Form layout="vertical" className="ai-draft-personalities__editor">
+                  <div className="ai-draft-personalities__editor-heading">
+                    <Checkbox
+                      checked={selectedPersonality.enabled}
+                      onChange={(event) => updateSelectedPersonality({ enabled: event.target.checked })}
+                    >
+                      Enabled
+                    </Checkbox>
+                    <Button icon="reload" disabled={selectedDefaultPersonality == null} onClick={restoreSelectedDefaultPersonality}>
+                      Restore Selected Default
+                    </Button>
+                  </div>
+
+                  <Form.Item
+                    label={
+                      <FieldLabel
+                        label="Label"
+                        help="Human-readable name for this voice profile. Labels are also used as a hint when matching personalities to a draft request."
+                      />
+                    }
+                  >
+                    <Input value={selectedPersonality.label} onChange={(event) => updateSelectedPersonality({ label: event.target.value })} />
+                  </Form.Item>
+
+                  <Form.Item
+                    label={
+                      <FieldLabel
+                        label="Cast ids"
+                        help="BattleTech cast ids that should use these rules. Include both short ids such as DariusDefault and cast definition ids such as castDef_DariusDefault when useful."
+                      />
+                    }
+                  >
+                    <Select
+                      mode="tags"
+                      tokenSeparators={[',', '\n']}
+                      value={selectedPersonality.castIds}
+                      placeholder="Add cast ids"
+                      onChange={(values: string[]) => updateSelectedPersonality({ castIds: normaliseIdTags(values) })}
+                    />
+                  </Form.Item>
+
+                  <Form.Item
+                    label={<FieldLabel label="Speaker ids" help="Conversation speaker ids from .cvsl speaker lists that should use these rules." />}
+                  >
+                    <Select
+                      mode="tags"
+                      tokenSeparators={[',', '\n']}
+                      value={selectedPersonality.speakerIds}
+                      placeholder="Add speaker ids"
+                      onChange={(values: string[]) => updateSelectedPersonality({ speakerIds: normaliseIdTags(values) })}
+                    />
+                  </Form.Item>
+
+                  <Form.Item
+                    label={
+                      <FieldLabel
+                        label="AI agent rules"
+                        help="Voice and behaviour rules the provider must follow whenever generated dialogue uses a matching cast id or speaker id."
+                      />
+                    }
+                  >
+                    <TextArea
+                      value={selectedPersonality.rules}
+                      rows={9}
+                      placeholder="Describe how this character speaks, what they notice, what they avoid, and how they should react under pressure."
+                      onChange={(event) => updateSelectedPersonality({ rules: event.target.value })}
+                    />
+                  </Form.Item>
+                </Form>
+              )}
+            </Col>
+          </Row>
+        </TabPane>
       </Tabs>
     </div>
   );
@@ -861,10 +1146,7 @@ function DraftPreview({
     () => (mode === 'fullConversation' ? null : buildPreviewConversationAssetFromDraft(draft, mode, workingDirectory, selectedNode)),
     [draft, mode, workingDirectory, selectedNode],
   );
-  const suggestedText = useMemo(
-    () => (mode === 'fullConversation' ? '' : getSuggestedNodeText(draft, selectedNode)),
-    [draft, mode, selectedNode],
-  );
+  const suggestedText = useMemo(() => (mode === 'fullConversation' ? '' : getSuggestedNodeText(draft, selectedNode)), [draft, mode, selectedNode]);
 
   return (
     <div className="ai-draft-preview">

--- a/app/src/components/AiDraftModal/AiDraftModal.tsx
+++ b/app/src/components/AiDraftModal/AiDraftModal.tsx
@@ -270,8 +270,8 @@ function AiDraftModal({ globalModalId, mode, selectedNodeId }: Props) {
       return;
     }
 
-    setValidation(validateAiDraft(draft, defStore.operations, mode));
-  }, [draft, mode, defStore.operations]);
+    setValidation(validateAiDraft(draft, defStore.operations, mode, selectedNode));
+  }, [draft, mode, selectedNode, defStore.operations]);
 
   const updateSettings = (patch: Partial<AiSettingsType>) => {
     console.log(`${AI_DEBUG_PREFIX} updateSettings`, {

--- a/app/src/components/AiDraftModal/AiDraftModal.tsx
+++ b/app/src/components/AiDraftModal/AiDraftModal.tsx
@@ -1,0 +1,899 @@
+import React, { ChangeEvent, useEffect, useMemo, useState } from 'react';
+import { toJS } from 'mobx';
+import { runInAction } from 'mobx';
+import { observer } from 'mobx-react';
+import { Alert, Button, Col, Form, Icon, Input, message, Row, Select, Spin, Tabs, Tag, Tooltip } from 'antd';
+
+import { useStore } from 'hooks/useStore';
+import { DataStore } from 'stores/dataStore/data-store';
+import { DefStore } from 'stores/defStore/def-store';
+import { ModalStore } from 'stores/modalStore/modal-store';
+import { NodeStore } from 'stores/nodeStore/node-store';
+import { AiContextPathPicker } from 'components/AiContextPathPicker';
+import { AiDraftConversationTreePreview } from './AiDraftConversationTreePreview';
+import { AiDraftArtifactViewer } from './AiDraftArtifactViewer';
+import {
+  createAiDraft,
+  getAiDraftArtifact,
+  getAiModels,
+  getAiSettings,
+  saveAiSettings,
+  saveAiWorkspaceSettings,
+  validateConversationRoundTrip,
+} from 'services/api';
+import {
+  addNodes,
+  getId,
+  updatePromptNode,
+  updateResponseNode,
+  updateRootNode,
+} from 'utils/conversation-utils';
+import {
+  buildAcceptedDraft,
+  buildPreviewConversationAssetFromDraft,
+  getSuggestedNodeText,
+  parseAiDraft,
+  validateAiDraft,
+} from 'utils/ai-draft-utils';
+import {
+  AiConversationDraftType,
+  AiDraftModeType,
+  AiDraftRunResultType,
+  AiDraftValidationResultType,
+  AiModelCatalogResultType,
+  AiSettingsType,
+  AiWorkspaceSettingsType,
+  ElementNodeType,
+  PromptNodeType,
+} from 'types';
+
+import './AiDraftModal.css';
+
+const { TextArea } = Input;
+const { Option } = Select;
+const { TabPane } = Tabs;
+const AI_DEBUG_PREFIX = '[ConverseTek AI Modal]';
+
+type Props = {
+  globalModalId: string;
+  mode: AiDraftModeType;
+  selectedNodeId?: string;
+};
+
+const emptySettings: AiSettingsType = {
+  enabled: true,
+  selectedProvider: 'codex',
+  codexCommand: 'codex',
+  codexModel: '',
+  codexProfile: '',
+  timeoutSeconds: 300,
+  modelCatalogs: {},
+  workspaces: {},
+};
+
+type ProviderUi = {
+  displayName: string;
+  commandLabel: string;
+  commandPlaceholder: string;
+  modelLabel: string;
+  profileLabel: string;
+  profilePlaceholder: string;
+};
+
+function getModeTitle(mode: AiDraftModeType): string {
+  if (mode === 'fullConversation') return 'AI Draft Conversation';
+  if (mode === 'branchExpansion') return 'AI Expand Branch';
+  return 'AI Suggest Node Text';
+}
+
+function getAcceptLabel(mode: AiDraftModeType): string {
+  if (mode === 'fullConversation') return 'Create From Preview';
+  return 'Accept';
+}
+
+function getDefaultCommandForProvider(providerName: string): string {
+  return providerName === 'claudecode' ? 'claude' : 'codex';
+}
+
+function getProviderUi(providerName: string): ProviderUi {
+  if (providerName === 'claudecode') {
+    return {
+      displayName: 'Claude Code CLI',
+      commandLabel: 'Claude Code command',
+      commandPlaceholder: 'claude',
+      modelLabel: 'Claude model',
+      profileLabel: 'Claude profile',
+      profilePlaceholder: 'Default Claude Code profile',
+    };
+  }
+
+  return {
+    displayName: 'Codex CLI',
+    commandLabel: 'Codex command',
+    commandPlaceholder: 'codex',
+    modelLabel: 'Codex model',
+    profileLabel: 'Codex profile',
+    profilePlaceholder: 'Default Codex profile',
+  };
+}
+
+function FieldLabel({ label, help }: { label: string; help: string }) {
+  return (
+    <span className="ai-draft-modal__field-label">
+      <span>{label}</span>
+      <Tooltip title={help}>
+        <Icon className="ai-draft-modal__help-icon" type="question-circle" />
+      </Tooltip>
+    </span>
+  );
+}
+
+function normaliseWorkspaceKey(path: string): string {
+  return path.replaceAll('\\', '/').replace(/\/+$/g, '').toLowerCase();
+}
+
+function createWorkspaceSettings(workingDirectory: string): AiWorkspaceSettingsType {
+  return {
+    workingDirectory,
+    contextPaths: [],
+    houseStyleNotes: '',
+    defaultCampaignBrief: '',
+  };
+}
+
+function AiDraftModal({ globalModalId, mode, selectedNodeId }: Props) {
+  const dataStore = useStore<DataStore>('data');
+  const defStore = useStore<DefStore>('def');
+  const modalStore = useStore<ModalStore>('modal');
+  const nodeStore = useStore<NodeStore>('node');
+
+  const [settings, setSettings] = useState<AiSettingsType>(emptySettings);
+  const [workspaceSettings, setWorkspaceSettings] = useState<AiWorkspaceSettingsType | null>(null);
+  const [brief, setBrief] = useState('');
+  const [draft, setDraft] = useState<AiConversationDraftType | null>(null);
+  const [validation, setValidation] = useState<AiDraftValidationResultType>({ errors: [], warnings: [] });
+  const [modelCatalog, setModelCatalog] = useState<AiModelCatalogResultType | null>(null);
+  const [diagnosticsPath, setDiagnosticsPath] = useState('');
+  const [draftRunResult, setDraftRunResult] = useState<AiDraftRunResultType | null>(null);
+  const [activeTab, setActiveTab] = useState('draft');
+  const [isLoading, setIsLoading] = useState(false);
+  const [isLoadingModels, setIsLoadingModels] = useState(false);
+  const [isSavingConfiguration, setIsSavingConfiguration] = useState(false);
+
+  const { workingDirectory, unsavedActiveConversationAsset } = dataStore;
+  const isVisible = modalStore.options.get(globalModalId)?.isVisible === true;
+  const selectedNode = useMemo(() => {
+    if (!selectedNodeId) return nodeStore.activeNode;
+    return nodeStore.getNode(selectedNodeId);
+  }, [selectedNodeId, nodeStore.activeNode]);
+  const providerName = settings.selectedProvider || 'codex';
+  const providerUi = getProviderUi(providerName);
+
+  const canGenerate = workingDirectory != null && (mode === 'fullConversation' || selectedNode != null);
+  const canAccept = draft != null && validation.errors.length === 0;
+
+  const getCachedModelCatalog = (targetSettings: AiSettingsType, targetProviderName: string) => {
+    const catalog = targetSettings.modelCatalogs ? targetSettings.modelCatalogs[targetProviderName] : null;
+    if (catalog == null || !catalog.models || catalog.models.length === 0) return null;
+    return {
+      ...catalog,
+      fromCache: true,
+    };
+  };
+
+  const loadModelCatalog = async (targetSettings: AiSettingsType, forceRefresh = false) => {
+    console.log(`${AI_DEBUG_PREFIX} loadModelCatalog start`, {
+      targetProvider: targetSettings.selectedProvider,
+      targetCodexModel: targetSettings.codexModel,
+      forceRefresh,
+    });
+
+    setIsLoadingModels(true);
+    try {
+      const result = await getAiModels(targetSettings, forceRefresh);
+      setModelCatalog(result);
+      console.log(`${AI_DEBUG_PREFIX} loadModelCatalog success`, {
+        provider: result.provider,
+        modelCount: result.models.length,
+        fromCache: result.fromCache,
+        currentStateCodexModel: settings.codexModel,
+        returnedModelSlugs: result.models.map((model) => model.slug),
+      });
+    } catch (error) {
+      console.log(`${AI_DEBUG_PREFIX} loadModelCatalog error`, error);
+      setModelCatalog({
+        success: false,
+        error: error instanceof Error ? error.message : 'Could not load provider models.',
+        provider: targetSettings.selectedProvider || 'unknown',
+        defaultModel: '',
+        fromCache: false,
+        models: [],
+      });
+    } finally {
+      setIsLoadingModels(false);
+    }
+  };
+
+  useEffect(() => {
+    modalStore.setTitle(getModeTitle(mode), globalModalId);
+    modalStore.setWidth('78vw', globalModalId);
+    modalStore.setShowOkButton(false, globalModalId);
+    modalStore.setShowCancelButton(true, globalModalId);
+    modalStore.setCancelLabel('Close', globalModalId);
+  }, []);
+
+  const loadConfiguration = async (refreshModelsForSettingsTab = false) => {
+    console.log(`${AI_DEBUG_PREFIX} loadConfiguration start`, {
+      refreshModelsForSettingsTab,
+      activeTab,
+      workingDirectory,
+      previousCodexModel: settings.codexModel,
+    });
+
+    try {
+      const loadedSettings = await getAiSettings();
+      console.log(`${AI_DEBUG_PREFIX} loadConfiguration loaded`, {
+        loadedSelectedProvider: loadedSettings.selectedProvider,
+        loadedCodexModel: loadedSettings.codexModel,
+        loadedModelCatalogKeys: Object.keys(loadedSettings.modelCatalogs || {}),
+      });
+
+      setSettings(loadedSettings);
+
+      const loadedProviderName = loadedSettings.selectedProvider || 'codex';
+      setModelCatalog(getCachedModelCatalog(loadedSettings, loadedProviderName));
+
+      if (workingDirectory) {
+        const key = normaliseWorkspaceKey(workingDirectory);
+        setWorkspaceSettings(loadedSettings.workspaces[key] || createWorkspaceSettings(workingDirectory));
+      }
+
+      if (refreshModelsForSettingsTab && activeTab === 'settings') {
+        void loadModelCatalog(loadedSettings, true);
+      }
+    } catch (error) {
+      console.log(`${AI_DEBUG_PREFIX} loadConfiguration error`, error);
+      void message.error(error instanceof Error ? error.message : 'Could not load AI settings.');
+    }
+  };
+
+  useEffect(() => {
+    if (!isVisible) return;
+
+    void loadConfiguration(true);
+  }, [isVisible, workingDirectory]);
+
+  useEffect(() => {
+    if (draft == null) {
+      setValidation({ errors: [], warnings: [] });
+      return;
+    }
+
+    setValidation(validateAiDraft(draft, defStore.operations, mode));
+  }, [draft, mode, defStore.operations]);
+
+  const updateSettings = (patch: Partial<AiSettingsType>) => {
+    console.log(`${AI_DEBUG_PREFIX} updateSettings`, {
+      patch,
+      previousCodexModel: settings.codexModel,
+      nextCodexModel: patch.codexModel ?? settings.codexModel,
+    });
+
+    setSettings((previousSettings) => ({
+      ...previousSettings,
+      ...patch,
+    }));
+  };
+
+  const updateWorkspaceSettings = (patch: Partial<AiWorkspaceSettingsType>) => {
+    setWorkspaceSettings((previousSettings) => ({
+      ...(previousSettings || createWorkspaceSettings(workingDirectory || '')),
+      ...patch,
+    }));
+  };
+
+  const addContextPath = (path: string) => {
+    const existingPaths = workspaceSettings?.contextPaths || [];
+    if (existingPaths.includes(path)) return;
+    updateWorkspaceSettings({ contextPaths: [...existingPaths, path] });
+  };
+
+  const openContextPathPicker = () => {
+    modalStore.setModelContent(
+      AiContextPathPicker,
+      {
+        initialPath: workingDirectory || undefined,
+        onSelectPath: addContextPath,
+      },
+      'global2',
+    );
+  };
+
+  const openDraftArtifact = async (title: string, path: string) => {
+    if (!path) {
+      void message.warning('No AI diagnostics file is available yet.');
+      return;
+    }
+
+    try {
+      const artifact = await getAiDraftArtifact(path);
+      if (!artifact.success) {
+        void message.error(artifact.error || 'Could not read AI diagnostics file.');
+        return;
+      }
+
+      modalStore.setModelContent(
+        AiDraftArtifactViewer,
+        {
+          title,
+          path: artifact.path,
+          content: artifact.content,
+          truncated: artifact.truncated,
+        },
+        'global2',
+      );
+    } catch (error) {
+      void message.error(error instanceof Error ? error.message : 'Could not read AI diagnostics file.');
+    }
+  };
+
+  const saveConfiguration = async (showSuccessMessage = false) => {
+    console.log(`${AI_DEBUG_PREFIX} saveConfiguration start`, {
+      showSuccessMessage,
+      selectedProvider: settings.selectedProvider,
+      codexModel: settings.codexModel,
+      hasWorkspaceSettings: workspaceSettings != null,
+    });
+
+    setIsSavingConfiguration(true);
+
+    try {
+      const updatedSettings = await saveAiSettings(settings);
+      let savedSettings = updatedSettings;
+      console.log(`${AI_DEBUG_PREFIX} saveConfiguration after saveAiSettings`, {
+        savedSelectedProvider: savedSettings.selectedProvider,
+        savedCodexModel: savedSettings.codexModel,
+      });
+
+      if (workspaceSettings != null) {
+        savedSettings = await saveAiWorkspaceSettings(workspaceSettings);
+        console.log(`${AI_DEBUG_PREFIX} saveConfiguration after saveAiWorkspaceSettings`, {
+          savedSelectedProvider: savedSettings.selectedProvider,
+          savedCodexModel: savedSettings.codexModel,
+        });
+      }
+
+      setSettings(savedSettings);
+      const savedProviderName = savedSettings.selectedProvider || 'codex';
+      setModelCatalog(getCachedModelCatalog(savedSettings, savedProviderName));
+
+      if (showSuccessMessage) {
+        void message.success('AI settings saved');
+      }
+    } catch (error) {
+      console.log(`${AI_DEBUG_PREFIX} saveConfiguration error`, error);
+      void message.error(error instanceof Error ? error.message : 'Could not save AI settings.');
+      throw error;
+    } finally {
+      console.log(`${AI_DEBUG_PREFIX} saveConfiguration finally`, {
+        codexModelAtFinally: settings.codexModel,
+      });
+      setIsSavingConfiguration(false);
+      modalStore.setIsLoading(false, globalModalId);
+      modalStore.setDisableOk(false, globalModalId);
+    }
+  };
+
+  useEffect(() => {
+    const isSettingsTab = activeTab === 'settings';
+
+    modalStore.setShowOkButton(isSettingsTab, globalModalId);
+    modalStore.setOkLabel('Save AI Settings', globalModalId);
+    modalStore.setDisableOk(isSavingConfiguration, globalModalId);
+    modalStore.setIsLoading(isSavingConfiguration, globalModalId);
+    modalStore.setLoadingLabel('Saving', globalModalId);
+    modalStore.setOnOk(() => {
+      void saveConfiguration(true);
+    }, globalModalId);
+  }, [activeTab, settings, workspaceSettings, isSavingConfiguration]);
+
+  const generateDraft = async () => {
+    if (!canGenerate || workingDirectory == null) {
+      void message.warning('Open a conversation folder and select a node when required before asking AI.');
+      return;
+    }
+
+    setIsLoading(true);
+    setDraft(null);
+    setDiagnosticsPath('');
+    setDraftRunResult(null);
+
+    try {
+      await saveConfiguration();
+      const result = await createAiDraft({
+        mode,
+        brief,
+        workingDirectory,
+        conversationJson: JSON.stringify(toJS(unsavedActiveConversationAsset), null, 2),
+        selectedNodeJson: JSON.stringify(toJS(selectedNode), null, 2),
+        definitionsJson: JSON.stringify(toJS({ operations: defStore.operations, presets: defStore.presets, tags: defStore.tags }), null, 2),
+      });
+
+      setDiagnosticsPath(result.diagnosticsDirectory);
+      setDraftRunResult(result);
+
+      if (!result.success) {
+        void message.error(result.error || 'AI draft generation failed.');
+        return;
+      }
+
+      setDraft(parseAiDraft(result.draftJson));
+      void message.success('AI draft generated');
+    } catch (error) {
+      void message.error(error instanceof Error ? error.message : 'AI draft generation failed.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const acceptDraft = async () => {
+    if (draft == null || workingDirectory == null) return;
+
+    try {
+      const acceptedDraft = buildAcceptedDraft(draft, mode, workingDirectory, selectedNode);
+
+      if (acceptedDraft.kind === 'fullConversation') {
+        const roundTripResult = await validateConversationRoundTrip(acceptedDraft.conversationAsset);
+        if (!roundTripResult.success) {
+          void message.error(`Generated conversation failed serialisation validation: ${roundTripResult.error}`);
+          return;
+        }
+
+        runInAction(() => {
+          dataStore.updateActiveConversation(acceptedDraft.conversationAsset);
+          dataStore.setConversationDirty(true);
+          nodeStore.setRebuild(true);
+        });
+      } else if (acceptedDraft.kind === 'nodeText') {
+        if (selectedNode == null) return;
+
+        runInAction(() => {
+          nodeStore.setNodeText(selectedNode, acceptedDraft.text);
+          nodeStore.setRebuild(true);
+        });
+      } else {
+        const activeConversation = dataStore.unsavedActiveConversationAsset;
+        if (activeConversation == null) return;
+
+        runInAction(() => {
+          const { parentElementNode, nodes } = acceptedDraft.patch;
+          addNodes(activeConversation, nodes);
+
+          if (parentElementNode.type === 'root') {
+            updateRootNode(activeConversation, parentElementNode);
+          } else {
+            const parentPromptNode = nodeStore.getNode(parentElementNode.parentId) as PromptNodeType;
+            updateResponseNode(activeConversation, parentPromptNode, parentElementNode);
+          }
+
+          nodes.forEach((node) => updatePromptNode(activeConversation, node));
+          dataStore.setConversationDirty(true);
+          nodeStore.setRebuild(true);
+        });
+      }
+
+      void message.success(mode === 'fullConversation' ? 'AI conversation draft is ready to save' : 'AI suggestion accepted');
+      modalStore.closeModal(globalModalId);
+    } catch (error) {
+      void message.error(error instanceof Error ? error.message : 'Could not accept AI draft.');
+    }
+  };
+
+  const contextPathsText = (workspaceSettings?.contextPaths || []).join('\n');
+  const selectedNodeLabel = selectedNode ? `${selectedNode.type} ${getId(selectedNode)}` : 'None';
+  const listedModelSlugs = new Set((modelCatalog?.models || []).map((model) => model.slug));
+  const shouldShowCustomModel = settings.codexModel !== '' && !listedModelSlugs.has(settings.codexModel);
+
+  console.log(`${AI_DEBUG_PREFIX} render`, {
+    activeTab,
+    isVisible,
+    providerName,
+    codexModel: settings.codexModel,
+    modelCatalogProvider: modelCatalog?.provider,
+    modelCatalogFromCache: modelCatalog?.fromCache,
+    listedModelSlugs: Array.from(listedModelSlugs),
+    shouldShowCustomModel,
+  });
+
+  const updateProvider = (nextProviderName: string) => {
+    const previousDefaultCommand = getDefaultCommandForProvider(providerName);
+    const nextDefaultCommand = getDefaultCommandForProvider(nextProviderName);
+    const currentCommand = settings.codexCommand || '';
+    const shouldUseNextDefault = currentCommand.trim() === '' || currentCommand === previousDefaultCommand;
+
+    const nextSettings = {
+      ...settings,
+      selectedProvider: nextProviderName,
+      codexCommand: shouldUseNextDefault ? nextDefaultCommand : currentCommand,
+      codexModel: '',
+    };
+
+    setSettings(nextSettings);
+    setModelCatalog(getCachedModelCatalog(nextSettings, nextProviderName));
+  };
+
+  const changeTab = (key: string) => {
+    console.log(`${AI_DEBUG_PREFIX} changeTab`, {
+      key,
+      codexModelBeforeTabChange: settings.codexModel,
+    });
+
+    setActiveTab(key);
+
+    if (key === 'settings') {
+      void loadModelCatalog(settings, true);
+    }
+  };
+
+  return (
+    <div className="ai-draft-modal">
+      <Tabs activeKey={activeTab} onChange={changeTab}>
+        <TabPane tab="Draft" key="draft">
+          {!canGenerate && (
+            <Alert
+              className="ai-draft-modal__alert"
+              type="warning"
+              message="This AI flow needs an open conversation folder and, for node or branch suggestions, a selected node."
+            />
+          )}
+
+          <Row gutter={16}>
+            <Col md={14}>
+              <Form layout="vertical">
+                <Form.Item
+                  label={
+                    <FieldLabel
+                      label="Brief"
+                      help="Describe what the AI should draft: story beats, tone, speakers, choices, required operations, and anything to avoid."
+                    />
+                  }
+                >
+                  <TextArea
+                    value={brief}
+                    onChange={(event: ChangeEvent<HTMLTextAreaElement>) => setBrief(event.target.value)}
+                    rows={7}
+                    placeholder="Describe the scene, tone, required beats, choices, tags, and anything the AI must avoid."
+                  />
+                </Form.Item>
+              </Form>
+            </Col>
+            <Col md={10}>
+              <div className="ai-draft-modal__meta">
+                <div>
+                  <span>Mode</span>
+                  <Tag>{mode}</Tag>
+                </div>
+                <div>
+                  <span>Selected</span>
+                  <Tag>{selectedNodeLabel}</Tag>
+                </div>
+                <div>
+                  <span>Provider</span>
+                  <Tag>{settings.selectedProvider || 'codex'}</Tag>
+                </div>
+                {diagnosticsPath && (
+                  <div>
+                    <span>Diagnostics</span>
+                    <code>{diagnosticsPath}</code>
+                  </div>
+                )}
+                {draftRunResult && (
+                  <div className="ai-draft-modal__artifact-actions">
+                    <span>Review</span>
+                    <div>
+                      <Button
+                        size="small"
+                        icon="file-text"
+                        disabled={!draftRunResult.promptPath}
+                        onClick={() => {
+                          void openDraftArtifact('AI Prompt Sent', draftRunResult.promptPath);
+                        }}
+                      >
+                        Prompt
+                      </Button>
+                      <Button
+                        size="small"
+                        icon="code"
+                        disabled={!draftRunResult.outputPath}
+                        onClick={() => {
+                          void openDraftArtifact('AI Response Received', draftRunResult.outputPath);
+                        }}
+                      >
+                        Response
+                      </Button>
+                    </div>
+                  </div>
+                )}
+              </div>
+            </Col>
+          </Row>
+
+          <div className="ai-draft-modal__actions">
+            <Button
+              type="primary"
+              disabled={!canGenerate || isLoading}
+              loading={isLoading}
+              onClick={() => {
+                void generateDraft();
+              }}
+            >
+              Generate Preview
+            </Button>
+            <Button
+              disabled={!canAccept || isLoading}
+              onClick={() => {
+                void acceptDraft();
+              }}
+            >
+              {getAcceptLabel(mode)}
+            </Button>
+            <Button disabled={draft == null || isLoading} onClick={() => setDraft(null)}>
+              Reject
+            </Button>
+          </div>
+
+          {isLoading && (
+            <div className="ai-draft-modal__loading">
+              <Spin />
+              <span>Waiting for AI draft...</span>
+            </div>
+          )}
+
+          {draft && (
+            <DraftPreview
+              draft={draft}
+              validation={validation}
+              mode={mode}
+              workingDirectory={workingDirectory || ''}
+              selectedNode={selectedNode}
+            />
+          )}
+        </TabPane>
+
+        <TabPane tab="Settings" key="settings">
+          <Row gutter={16}>
+            <Col md={10}>
+              <Form layout="vertical">
+                <Form.Item
+                  label={
+                    <FieldLabel
+                      label="Provider"
+                      help="Select the CLI provider ConverseTek will call. Codex is implemented now; Claude Code is reserved for the next provider."
+                    />
+                  }
+                >
+                  <Select value={providerName} onChange={updateProvider}>
+                    <Option value="codex">Codex CLI</Option>
+                    <Option value="claudecode">Claude Code CLI (planned)</Option>
+                  </Select>
+                </Form.Item>
+                {providerName !== 'codex' && (
+                  <Alert
+                    className="ai-draft-modal__alert"
+                    type="info"
+                    message={`${providerUi.displayName} settings can be prepared here, but only Codex runs drafts in this version.`}
+                  />
+                )}
+                <Form.Item
+                  label={
+                    <FieldLabel
+                      label={providerUi.commandLabel}
+                      help={`Executable or full path for ${providerUi.displayName}. Use the default when the command is already on PATH.`}
+                    />
+                  }
+                >
+                  <Input
+                    value={settings.codexCommand}
+                    placeholder={providerUi.commandPlaceholder}
+                    onChange={(event) => updateSettings({ codexCommand: event.target.value })}
+                  />
+                </Form.Item>
+                <Form.Item
+                  label={
+                    <FieldLabel label={providerUi.modelLabel} help="Fetched from the provider CLI. Leave as provider default/latest to avoid pinning to a specific model." />
+                  }
+                >
+                  <div className="ai-draft-modal__model-row">
+                    <Select
+                      value={settings.codexModel || ''}
+                      loading={isLoadingModels}
+                      onChange={(value: string) => {
+                        console.log(`${AI_DEBUG_PREFIX} model Select onChange`, {
+                          value,
+                          previousCodexModel: settings.codexModel,
+                        });
+                        updateSettings({ codexModel: value });
+                      }}
+                    >
+                      <Option value="">Provider default/latest</Option>
+                      {shouldShowCustomModel && <Option value={settings.codexModel}>{settings.codexModel} (custom)</Option>}
+                      {(modelCatalog?.models || []).map((model) => (
+                        <Option key={model.slug} value={model.slug}>
+                          {model.displayName || model.slug}
+                        </Option>
+                      ))}
+                    </Select>
+                    <Tooltip title="Poll the provider CLI again for the latest model catalogue.">
+                      <Button
+                        icon="reload"
+                        loading={isLoadingModels}
+                        onClick={() => {
+                          void loadModelCatalog(settings, true);
+                        }}
+                      >
+                        Refresh
+                      </Button>
+                    </Tooltip>
+                  </div>
+                  {modelCatalog && modelCatalog.error && (
+                    <Alert className="ai-draft-modal__inline-alert" type="warning" message={modelCatalog.error || 'Could not load provider models.'} />
+                  )}
+                  {modelCatalog?.success && (
+                    <div className="ai-draft-modal__field-note">
+                      {modelCatalog.models.length} model{modelCatalog.models.length === 1 ? '' : 's'} loaded from {modelCatalog.provider}.
+                      {modelCatalog.fromCache ? ' Using saved list.' : ''}
+                    </div>
+                  )}
+                </Form.Item>
+                <Form.Item
+                  label={
+                    <FieldLabel
+                      label={providerUi.profileLabel}
+                      help="Optional CLI profile/config name. Leave blank to use your normal provider profile."
+                    />
+                  }
+                >
+                  <Input
+                    value={settings.codexProfile}
+                    placeholder={providerUi.profilePlaceholder}
+                    onChange={(event) => updateSettings({ codexProfile: event.target.value })}
+                  />
+                </Form.Item>
+                <Form.Item
+                  label={
+                    <FieldLabel
+                      label="Timeout seconds"
+                      help="Maximum time ConverseTek waits for the provider before treating the draft run as failed."
+                    />
+                  }
+                >
+                  <Input
+                    value={settings.timeoutSeconds.toString()}
+                    placeholder="300"
+                    onChange={(event) => updateSettings({ timeoutSeconds: Number(event.target.value) || 300 })}
+                  />
+                </Form.Item>
+              </Form>
+            </Col>
+            <Col md={14}>
+              <Form layout="vertical">
+                <Form.Item
+                  label={
+                    <FieldLabel
+                      label="Context files and folders"
+                      help="One file or folder path per line. ConverseTek includes supported text files as read-only context. Examples: a DeadClaim outline markdown file; a folder containing existing conversation exports."
+                    />
+                  }
+                >
+                  <TextArea
+                    value={contextPathsText}
+                    rows={7}
+                    placeholder="One path per line"
+                    onChange={(event) =>
+                      updateWorkspaceSettings({
+                        contextPaths: event.target.value
+                          .split('\n')
+                          .map((line) => line.trim())
+                          .filter(Boolean),
+                      })
+                    }
+                  />
+                  <div className="ai-draft-modal__field-actions">
+                    <Button icon="folder-open" onClick={openContextPathPicker}>
+                      Browse...
+                    </Button>
+                  </div>
+                </Form.Item>
+                <Form.Item
+                  label={
+                    <FieldLabel
+                      label="House style notes"
+                      help="Reusable tone and formatting guidance for this conversation folder. Examples: keep dropship lines short and practical; Darius should sound wary but professional."
+                    />
+                  }
+                >
+                  <TextArea
+                    value={workspaceSettings?.houseStyleNotes || ''}
+                    rows={4}
+                    placeholder="Optional style guidance"
+                    onChange={(event) => updateWorkspaceSettings({ houseStyleNotes: event.target.value })}
+                  />
+                </Form.Item>
+                <Form.Item
+                  label={
+                    <FieldLabel
+                      label="Default campaign brief"
+                      help="Standing campaign context that should be available to every draft in this workspace. Examples: part 1/part 2 structure; recurring cast, current campaign state, and plot constraints."
+                    />
+                  }
+                >
+                  <TextArea
+                    value={workspaceSettings?.defaultCampaignBrief || ''}
+                    rows={4}
+                    placeholder="Optional campaign context"
+                    onChange={(event) => updateWorkspaceSettings({ defaultCampaignBrief: event.target.value })}
+                  />
+                </Form.Item>
+              </Form>
+            </Col>
+          </Row>
+        </TabPane>
+      </Tabs>
+    </div>
+  );
+}
+
+function DraftPreview({
+  draft,
+  validation,
+  mode,
+  workingDirectory,
+  selectedNode,
+}: {
+  draft: AiConversationDraftType;
+  validation: AiDraftValidationResultType;
+  mode: AiDraftModeType;
+  workingDirectory: string;
+  selectedNode: PromptNodeType | ElementNodeType | null;
+}) {
+  const previewConversationAsset = useMemo(
+    () => buildPreviewConversationAssetFromDraft(draft, mode, workingDirectory, selectedNode),
+    [draft, mode, workingDirectory, selectedNode],
+  );
+  const suggestedText = useMemo(() => getSuggestedNodeText(draft, selectedNode), [draft, selectedNode]);
+
+  return (
+    <div className="ai-draft-preview">
+      <div className="ai-draft-preview__summary">
+        <h3>{draft.title}</h3>
+        <p>{draft.summary}</p>
+      </div>
+
+      {validation.errors.length > 0 && (
+        <Alert className="ai-draft-modal__alert" type="error" message="Draft errors" description={validation.errors.join('\n')} />
+      )}
+      {validation.warnings.length > 0 && (
+        <Alert className="ai-draft-modal__alert" type="warning" message="Draft warnings" description={validation.warnings.join('\n')} />
+      )}
+
+      {(draft.cast || []).length > 0 && (
+        <div className="ai-draft-preview__cast">
+          {(draft.cast || []).map((castMember) => (
+            <Tag key={castMember.id}>{castMember.label || castMember.id}</Tag>
+          ))}
+        </div>
+      )}
+
+      {previewConversationAsset ? (
+        <AiDraftConversationTreePreview conversationAsset={previewConversationAsset} />
+      ) : (
+        <div className="ai-draft-preview__suggestion">
+          <h4>Suggested text</h4>
+          <p>{suggestedText}</p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export const ObservingAiDraftModal = observer(AiDraftModal);

--- a/app/src/components/AiDraftModal/AiDraftModal.tsx
+++ b/app/src/components/AiDraftModal/AiDraftModal.tsx
@@ -989,7 +989,7 @@ function AiDraftModal({ globalModalId, mode, selectedNodeId }: Props) {
         </TabPane>
 
         <TabPane tab="Cast Personalities" key="cast-personalities">
-          <Row gutter={16}>
+          <Row gutter={24} className="ai-draft-personalities">
             <Col md={9}>
               <div className="ai-draft-personalities__toolbar">
                 <Input

--- a/app/src/components/AiDraftModal/AiDraftModal.tsx
+++ b/app/src/components/AiDraftModal/AiDraftModal.tsx
@@ -3,6 +3,7 @@ import { toJS } from 'mobx';
 import { runInAction } from 'mobx';
 import { observer } from 'mobx-react';
 import { Alert, Button, Col, Form, Icon, Input, message, Row, Select, Spin, Tabs, Tag, Tooltip } from 'antd';
+import classnames from 'classnames';
 
 import { useStore } from 'hooks/useStore';
 import { DataStore } from 'stores/dataStore/data-store';
@@ -87,7 +88,7 @@ function getModeTitle(mode: AiDraftModeType): string {
 }
 
 function getAcceptLabel(mode: AiDraftModeType): string {
-  if (mode === 'fullConversation') return 'Create From Preview';
+  if (mode === 'fullConversation') return 'Open In Main Editor';
   return 'Accept';
 }
 
@@ -216,7 +217,7 @@ function AiDraftModal({ globalModalId, mode, selectedNodeId }: Props) {
 
   useEffect(() => {
     modalStore.setTitle(getModeTitle(mode), globalModalId);
-    modalStore.setWidth('78vw', globalModalId);
+    modalStore.setWidth(mode === 'fullConversation' ? '74vw' : '86vw', globalModalId);
     modalStore.setShowOkButton(false, globalModalId);
     modalStore.setShowCancelButton(true, globalModalId);
     modalStore.setCancelLabel('Close', globalModalId);
@@ -536,7 +537,7 @@ function AiDraftModal({ globalModalId, mode, selectedNodeId }: Props) {
   };
 
   return (
-    <div className="ai-draft-modal">
+    <div className={classnames('ai-draft-modal', draft && 'ai-draft-modal--has-draft')}>
       <Tabs activeKey={activeTab} onChange={changeTab}>
         <TabPane tab="Draft" key="draft">
           {!canGenerate && (
@@ -561,7 +562,7 @@ function AiDraftModal({ globalModalId, mode, selectedNodeId }: Props) {
                   <TextArea
                     value={brief}
                     onChange={(event: ChangeEvent<HTMLTextAreaElement>) => setBrief(event.target.value)}
-                    rows={7}
+                    rows={draft ? 4 : 7}
                     placeholder="Describe the scene, tone, required beats, choices, tags, and anything the AI must avoid."
                   />
                 </Form.Item>
@@ -857,7 +858,7 @@ function DraftPreview({
   selectedNode: PromptNodeType | ElementNodeType | null;
 }) {
   const previewConversationAsset = useMemo(
-    () => buildPreviewConversationAssetFromDraft(draft, mode, workingDirectory, selectedNode),
+    () => (mode === 'fullConversation' ? null : buildPreviewConversationAssetFromDraft(draft, mode, workingDirectory, selectedNode)),
     [draft, mode, workingDirectory, selectedNode],
   );
   const suggestedText = useMemo(() => getSuggestedNodeText(draft, selectedNode), [draft, selectedNode]);

--- a/app/src/components/AiDraftModal/AiDraftModal.tsx
+++ b/app/src/components/AiDraftModal/AiDraftModal.tsx
@@ -861,7 +861,10 @@ function DraftPreview({
     () => (mode === 'fullConversation' ? null : buildPreviewConversationAssetFromDraft(draft, mode, workingDirectory, selectedNode)),
     [draft, mode, workingDirectory, selectedNode],
   );
-  const suggestedText = useMemo(() => getSuggestedNodeText(draft, selectedNode), [draft, selectedNode]);
+  const suggestedText = useMemo(
+    () => (mode === 'fullConversation' ? '' : getSuggestedNodeText(draft, selectedNode)),
+    [draft, mode, selectedNode],
+  );
 
   return (
     <div className="ai-draft-preview">
@@ -885,14 +888,14 @@ function DraftPreview({
         </div>
       )}
 
-      {previewConversationAsset ? (
+      {previewConversationAsset != null ? (
         <AiDraftConversationTreePreview conversationAsset={previewConversationAsset} />
-      ) : (
+      ) : mode !== 'fullConversation' ? (
         <div className="ai-draft-preview__suggestion">
           <h4>Suggested text</h4>
           <p>{suggestedText}</p>
         </div>
-      )}
+      ) : null}
     </div>
   );
 }

--- a/app/src/components/AiDraftModal/index.ts
+++ b/app/src/components/AiDraftModal/index.ts
@@ -1,0 +1,1 @@
+export { ObservingAiDraftModal as AiDraftModal } from './AiDraftModal';

--- a/app/src/components/ContextMenus/DialogEditorContextMenu/DialogEditorContextMenu.tsx
+++ b/app/src/components/ContextMenus/DialogEditorContextMenu/DialogEditorContextMenu.tsx
@@ -5,9 +5,11 @@ import { observer } from 'mobx-react';
 import 'react-contexify/ReactContexify.css';
 
 import { useStore } from 'hooks/useStore';
+import { useAiFeatureEnabled } from 'hooks/useAiFeatureEnabled';
 import { NodeStore } from 'stores/nodeStore/node-store';
 import { ModalStore } from 'stores/modalStore/modal-store';
 import { detectType, isAllowedToCreateNode, isAllowedToPasteCopy, isAllowedToPasteLink } from 'utils/node-utils';
+import { AiDraftModal } from 'components/AiDraftModal';
 import { handleDeleteIntent } from './handle-delete';
 
 export type EventProps = {
@@ -38,6 +40,7 @@ function getAddLabel(type: string) {
 export function DialogEditorContextMenu({ id, onVisibilityChange }: { id: string; onVisibilityChange: (flag: boolean) => void }) {
   const nodeStore = useStore<NodeStore>('node');
   const modalStore = useStore<ModalStore>('modal');
+  const aiFeatureEnabled = useAiFeatureEnabled(true);
   const { hideAll } = useContextMenu({
     id,
   });
@@ -53,6 +56,8 @@ export function DialogEditorContextMenu({ id, onVisibilityChange }: { id: string
   const allowAdd = isAllowedToCreateNode(focusedNodeId);
   const allowedToPasteCopy = isAllowedToPasteCopy(focusedNodeId, clipboard);
   const allowedToPasteLink = isAllowedToPasteLink(focusedNodeId, clipboard);
+  const showAiActions = aiFeatureEnabled && (isNode || isResponse || isRoot);
+  const showBranchActions = isNode || isResponse || isRoot;
 
   const onAddClicked = ({ props }: ItemParams<EventProps>) => {
     if (!props) return;
@@ -81,6 +86,18 @@ export function DialogEditorContextMenu({ id, onVisibilityChange }: { id: string
   const onDeleteClicked = ({ props }: ItemParams<EventProps>) => {
     if (!props) return;
     handleDeleteIntent({ props, nodeStore, modalStore });
+    hideAll();
+  };
+
+  const onAiSuggestNode = ({ props }: ItemParams<EventProps>) => {
+    if (!props) return;
+    modalStore.setModelContent(AiDraftModal, { mode: 'nodeSuggestion', selectedNodeId: props.id }, 'global1');
+    hideAll();
+  };
+
+  const onAiExpandBranch = ({ props }: ItemParams<EventProps>) => {
+    if (!props) return;
+    modalStore.setModelContent(AiDraftModal, { mode: 'branchExpansion', selectedNodeId: props.id }, 'global1');
     hideAll();
   };
 
@@ -133,7 +150,10 @@ export function DialogEditorContextMenu({ id, onVisibilityChange }: { id: string
       {allowedToPasteCopy && <Item onClick={onPasteAsCopy}>Paste as Copy</Item>}
       {allowedToPasteLink && <Item onClick={onPasteAsLink}>Paste as Link</Item>}
       {!isCore && <Item onClick={onDeleteClicked}>Delete</Item>}
-      {(isNode || isResponse || isRoot) && <Separator />}
+      {showAiActions && <Separator />}
+      {showAiActions && <Item onClick={onAiSuggestNode}>AI Suggest Rewrite</Item>}
+      {aiFeatureEnabled && (isResponse || isRoot) && <Item onClick={onAiExpandBranch}>AI Expand Branch</Item>}
+      {showBranchActions && <Separator />}
       {(isNode || isResponse) && <Item onClick={onIsolateBranch}>Isolate Branch</Item>}
       {(isNode || isResponse || isRoot) && <Item onClick={onExpandBranch}>Expand Branch</Item>}
       {(isNode || isResponse || isRoot) && <Item onClick={onCollapseBranch}>Collapse Branch</Item>}

--- a/app/src/components/ContextMenus/DialogEditorContextMenu/__tests__/handle-delete.test.ts
+++ b/app/src/components/ContextMenus/DialogEditorContextMenu/__tests__/handle-delete.test.ts
@@ -43,8 +43,8 @@ function makePromptNode(index: number, branches: ElementNodeType[] = []): Prompt
 
 function buildFakes(promptNode: PromptNodeType, inboundLinks: ElementNodeType[]) {
   const nodeStore = {
-    getNode: vi.fn((_id: string) => promptNode),
-    getInboundLinksToPromptNodeIndex: vi.fn((_i: number) => inboundLinks),
+    getNode: vi.fn(() => promptNode),
+    getInboundLinksToPromptNodeIndex: vi.fn(() => inboundLinks),
     deleteNodeCascadeById: vi.fn(),
     deleteLink: vi.fn(),
   };
@@ -65,19 +65,24 @@ describe('CT-128: delete flow opens the confirmation modal', () => {
     });
 
     expect(modalStore.setModelContent).toHaveBeenCalledTimes(1);
-    const [componentArg, modalProps, globalModalId] = modalStore.setModelContent.mock.calls[0];
+    const firstModalCall = modalStore.setModelContent.mock.calls[0] as unknown as [
+      unknown,
+      { body: string | string[]; buttons: { onPositive: () => void } },
+      string,
+    ];
+    const [componentArg, modalProps, globalModalId] = firstModalCall;
 
     expect(componentArg).toBe('ModalConfirmationStub');
     expect(globalModalId).toBe('global1');
 
-    const body = (modalProps as { body: string | string[] }).body;
+    const { body } = modalProps;
     expect(Array.isArray(body)).toBe(true);
     const joined = (body as string[]).join(' ');
     expect(joined).toMatch(/1 response node links to this prompt node/i);
     expect(joined).toMatch(/End of Dialogue/);
 
     // Confirming the modal must still trigger the cascade delete.
-    const buttons = (modalProps as { buttons: { onPositive: () => void } }).buttons;
+    const { buttons } = modalProps;
     buttons.onPositive();
     expect(nodeStore.deleteNodeCascadeById).toHaveBeenCalledWith('prompt-5-id');
     expect(nodeStore.deleteLink).not.toHaveBeenCalled();

--- a/app/src/components/DialogEditor/ConverseTekNodeRenderer/ConverseTekNodeRenderer.css
+++ b/app/src/components/DialogEditor/ConverseTekNodeRenderer/ConverseTekNodeRenderer.css
@@ -101,6 +101,27 @@
     }
   }
 
+  &__speaker-badge {
+    display: inline-flex;
+    align-items: center;
+    max-width: 86px;
+    height: 16px;
+    margin-right: 7px;
+    overflow: hidden;
+    padding: 0 6px;
+    border-radius: 2px;
+    background: #e6f0ff;
+    box-shadow: inset 0 0 0 1px rgba(47, 113, 212, 0.22);
+    color: #1f5f9f;
+    font-size: 9px;
+    font-weight: 700;
+    line-height: 16px;
+    text-overflow: ellipsis;
+    text-transform: uppercase;
+    vertical-align: 1px;
+    white-space: nowrap;
+  }
+
   &__link {
     display: flex;
     width: 100%;

--- a/app/src/components/DialogEditor/ConverseTekNodeRenderer/ConverseTekNodeRenderer.tsx
+++ b/app/src/components/DialogEditor/ConverseTekNodeRenderer/ConverseTekNodeRenderer.tsx
@@ -7,14 +7,13 @@ import { Icon } from 'antd';
 import defer from 'lodash.defer';
 import tinycolor from 'tinycolor2';
 
-import { OnNodeContextMenuProps } from '../DialogEditor';
-import { PromptNodeType, ElementNodeType, ColourConfigType } from 'types';
+import type { OnNodeContextMenuProps } from '../DialogEditor';
+import type { PromptNodeType, ElementNodeType, ColourConfigType } from 'types';
 
 import { isDescendant } from 'utils/tree-data-utils';
 import { detectType } from 'utils/node-utils';
 
 import { DataStore } from 'stores/dataStore/data-store';
-import { NodeStore } from 'stores/nodeStore/node-store';
 
 import { LinkIcon } from '../../Svg';
 
@@ -26,9 +25,22 @@ type NodeStateProps = {
   treeIndex: number;
 };
 
-type Props = {
+export type ConversationTreeNodeStore = {
+  getNode: (nodeId: string | undefined) => PromptNodeType | ElementNodeType | null;
+  getPromptNodeByIndex: (index: number) => PromptNodeType | null;
+  getTreeIndex: (nodeId: string) => number | undefined;
+  setActiveNode: (nodeId: string) => void;
+  initScrollToNode: (nodeId: string, direction: 'up' | 'down', cachedTree?: HTMLElement, skipHorizontalScroll?: boolean) => void;
+  isNodeVisible: (nodeId: string) => boolean;
+  setFocusedTreeNode: (node: RSTNode) => void;
+  getMaxTreeHorizontalNodePosition: () => number;
+  setNodeExpansion: (nodeId: string | undefined, flag: boolean) => void;
+  isNodeExpanded: (nodeId: string | undefined) => boolean;
+};
+
+export type ConverseTekNodeRendererProps = {
   dataStore: DataStore;
-  nodeStore: NodeStore;
+  nodeStore: ConversationTreeNodeStore;
   activeNodeId: string | null;
   previousNodeId: string | null;
   onNodeContextMenu: (props: OnNodeContextMenuProps) => void;
@@ -96,7 +108,7 @@ function getHighlightColour(colourConfig: ColourConfigType, nodeType: string): s
   return '';
 }
 
-function getTruncatedLinkText(nodeStore: NodeStore, linkIndex: number, maxLength: number) {
+function getTruncatedLinkText(nodeStore: ConversationTreeNodeStore, linkIndex: number, maxLength: number) {
   const linkedPromptNode = nodeStore.getPromptNodeByIndex(linkIndex);
   if (linkedPromptNode == null) return '';
 
@@ -138,7 +150,7 @@ export const ConverseTekNodeRenderer = observer(
     rowDirection = 'ltr',
     zoomLevel,
     ...otherProps
-  }: Props) => {
+  }: ConverseTekNodeRendererProps) => {
     const nodeRef = useRef<HTMLDivElement>(null);
 
     const nodeSubtitle = subtitle || node.subtitle;
@@ -151,6 +163,8 @@ export const ConverseTekNodeRenderer = observer(
     const canNodeBeDragged = !(node.canDrag === false);
     const [isHoveringOver, setIsHoveringOver] = useState<boolean>(false);
     const { colourConfig } = dataStore;
+    const rendererOnlyProps = [canDrag, treeId, isOver, parentNode];
+    void rendererOnlyProps;
 
     if (colourConfig == null) return null;
 

--- a/app/src/components/DialogEditor/ConverseTekNodeRenderer/ConverseTekNodeRenderer.tsx
+++ b/app/src/components/DialogEditor/ConverseTekNodeRenderer/ConverseTekNodeRenderer.tsx
@@ -36,6 +36,7 @@ export type ConversationTreeNodeStore = {
   getMaxTreeHorizontalNodePosition: () => number;
   setNodeExpansion: (nodeId: string | undefined, flag: boolean) => void;
   isNodeExpanded: (nodeId: string | undefined) => boolean;
+  getSpeakerRevision?: () => number;
 };
 
 export type ConverseTekNodeRendererProps = {
@@ -116,6 +117,29 @@ function getTruncatedLinkText(nodeStore: ConversationTreeNodeStore, linkIndex: n
   return text.length < maxLength ? text : `${text.substring(0, maxLength)}...`;
 }
 
+function getPromptSpeakerBadge(node: PromptNodeType | ElementNodeType | null): { label: string; title: string } | null {
+  if (node == null || node.type !== 'node') return null;
+
+  let speaker = '';
+  if (node.speakerType === 'castId') {
+    speaker = node.sourceInSceneRef?.id || '';
+  } else if (node.speakerType === 'speakerId') {
+    speaker = node.speakerOverrideId || '';
+  }
+
+  if (!speaker) {
+    return {
+      label: 'Inherits',
+      title: 'No node speaker; BattleTech reuses the current conversation speaker',
+    };
+  }
+
+  return {
+    label: speaker.replace(/Default$/i, '') || speaker,
+    title: `${node.speakerType || 'speaker'} ${speaker}`,
+  };
+}
+
 /* eslint-disable jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
 export const ConverseTekNodeRenderer = observer(
   ({
@@ -159,12 +183,14 @@ export const ConverseTekNodeRenderer = observer(
     const isActiveNode = activeNodeId === node.id;
     const wasPreviousActiveNode = previousNodeId === node.id;
     const storedNode = nodeStore.getNode(node.id);
+    const speakerRevision = nodeStore.getSpeakerRevision ? nodeStore.getSpeakerRevision() : 0;
     const { type: nodeType } = node;
     const canNodeBeDragged = !(node.canDrag === false);
     const [isHoveringOver, setIsHoveringOver] = useState<boolean>(false);
     const { colourConfig } = dataStore;
     const rendererOnlyProps = [canDrag, treeId, isOver, parentNode];
     void rendererOnlyProps;
+    void speakerRevision;
 
     if (colourConfig == null) return null;
 
@@ -329,6 +355,7 @@ export const ConverseTekNodeRenderer = observer(
           })
         : nodeTitle;
     const hasNodeTitle = typeof resolvedNodeTitle === 'string' && resolvedNodeTitle.length > 0;
+    const speakerBadge = getPromptSpeakerBadge(storedNode);
 
     const rowContents = (
       <div
@@ -391,6 +418,11 @@ export const ConverseTekNodeRenderer = observer(
             </div>
 
             <div className={labelClasses}>
+              {speakerBadge && (
+                <span className="node-renderer__speaker-badge" title={speakerBadge.title}>
+                  {speakerBadge.label}
+                </span>
+              )}
               <span className={titleClasses}>{resolvedNodeTitle}</span>
 
               {nodeSubtitle && (

--- a/app/src/components/DialogEditor/DialogEditor.tsx
+++ b/app/src/components/DialogEditor/DialogEditor.tsx
@@ -25,7 +25,7 @@ import { collapseOrExpandBranches, collapseOtherBranches, expandFromCoreToNode }
 
 import { ScalableScrollbar } from 'components/ScalableScrollbar';
 
-import { ConverseTekNodeRenderer } from './ConverseTekNodeRenderer';
+import { ConverseTekNodeRenderer, ConverseTekNodeRendererProps } from './ConverseTekNodeRenderer';
 import { DialogEditorContextMenu } from '../ContextMenus/DialogEditorContextMenu';
 
 import './DialogEditor.css';
@@ -495,7 +495,7 @@ function DialogEditor({ conversationAsset, rebuild, expandAll }: { conversationA
               isContextMenuVisible,
               zoomLevel,
             })}
-            nodeContentRenderer={(props: any) => <ConverseTekNodeRenderer {...props} />}
+            nodeContentRenderer={(props: ConverseTekNodeRendererProps) => <ConverseTekNodeRenderer {...props} />}
             reactVirtualizedListProps={{
               width: treeWidth,
             }}

--- a/app/src/components/EditableSelect/EditableSelect.tsx
+++ b/app/src/components/EditableSelect/EditableSelect.tsx
@@ -5,15 +5,14 @@ import { SelectValue } from 'antd/lib/select';
 
 const { Option } = Select;
 
+type SelectOptionElement = ReactElement<unknown, string | JSXElementConstructor<unknown>>;
+
 type Props = {
   value: string | null;
   options: string[] | { key: string }[];
   placeholder: string;
   style?: object;
-  onChange: (
-    value: SelectValue,
-    option: ReactElement<any, string | JSXElementConstructor<any>> | ReactElement<any, string | JSXElementConstructor<any>>[],
-  ) => void;
+  onChange: (value: SelectValue, option: SelectOptionElement | SelectOptionElement[]) => void;
 };
 
 function EditableSelect({ value, options, placeholder, style = {}, onChange }: Props) {

--- a/app/src/components/FileTree/FileTree.tsx
+++ b/app/src/components/FileTree/FileTree.tsx
@@ -66,7 +66,8 @@ const FileTree = ({ title, data = null, onSelected = () => {}, selectedKeys = []
     const { eventKey } = node.props;
     if (eventKey === '0') return;
 
-    show({ event, props: { id: eventKey, title: node.props.title, selected: node.props.selected } });
+    const item = data?.find((conversation) => conversation.key === eventKey);
+    show({ event, props: { id: eventKey, title: item?.label || String(eventKey), selected: node.props.selected } });
   };
 
   return (

--- a/app/src/components/Modals/ModalConfirmation/ModalConfirmation.tsx
+++ b/app/src/components/Modals/ModalConfirmation/ModalConfirmation.tsx
@@ -25,7 +25,9 @@ type Props = {
   closable: boolean;
 };
 
-function renderTitleWithType(title: string) {
+function renderTitleWithType(title: string, type: string) {
+  void type;
+
   return (
     <>
       <Icon type="exclamation-circle" theme="twoTone" twoToneColor="orange" className="modal-confirmation__icon--warning" />
@@ -43,7 +45,7 @@ export function ModalConfirmation({ globalModalId, type, title, header, body, wi
   };
 
   const setupModal = (): void => {
-    modalStore.setTitle(renderTitleWithType(title), globalModalId);
+    modalStore.setTitle(renderTitleWithType(title, type), globalModalId);
 
     if (buttons?.positiveLabel) {
       if (buttons.positiveType != null) modalStore.setOkType(buttons.positiveType, globalModalId);

--- a/app/src/components/Modals/ModalSimpleInput/ModalSimpleInput.tsx
+++ b/app/src/components/Modals/ModalSimpleInput/ModalSimpleInput.tsx
@@ -26,6 +26,8 @@ type Props = {
 };
 
 function renderTitleWithType(title: string, type: string) {
+  void type;
+
   return (
     <>
       {/* <Icon type="exclamation-circle" theme="twoTone" twoToneColor="orange" className="modal-confirmation__icon--warning" /> */}

--- a/app/src/containers/Header/Header.tsx
+++ b/app/src/containers/Header/Header.tsx
@@ -3,12 +3,14 @@ import { message, Menu } from 'antd';
 import { observer } from 'mobx-react';
 
 import { useStore } from 'hooks/useStore';
+import { useAiFeatureEnabled } from 'hooks/useAiFeatureEnabled';
 import { DataStore } from 'stores/dataStore/data-store';
 import { ModalStore } from 'stores/modalStore/modal-store';
 
 import { FileSystemPicker } from 'components/FileSystemPicker';
 import { SaveConversationAs } from 'components/SaveConversationAs';
 import { About } from 'components/About';
+import { AiDraftModal } from 'components/AiDraftModal';
 import { updateConversation, exportConversation, exportAllConversations } from 'services/api';
 
 import './Header.css';
@@ -19,6 +21,7 @@ const { SubMenu } = Menu;
 export function Header() {
   const dataStore = useStore<DataStore>('data');
   const modalStore = useStore<ModalStore>('modal');
+  const aiFeatureEnabled = useAiFeatureEnabled(true);
 
   const { workingDirectory } = dataStore;
   const hasActiveConversation = dataStore.activeConversationAsset !== null;
@@ -87,6 +90,13 @@ export function Header() {
             </MenuItem>
           )}
         </SubMenu>
+        {workingDirectory && aiFeatureEnabled && (
+          <SubMenu title="AI">
+            <MenuItem onClick={() => modalStore.setModelContent(AiDraftModal, { mode: 'fullConversation' }, 'global1')}>
+              Draft Conversation...
+            </MenuItem>
+          </SubMenu>
+        )}
         <SubMenu title="Help">
           <MenuItem onClick={() => modalStore.setModelContent(About, {}, 'global1')}>About</MenuItem>
         </SubMenu>

--- a/app/src/hooks/useAiFeatureEnabled.ts
+++ b/app/src/hooks/useAiFeatureEnabled.ts
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react';
+
+import { AI_SETTINGS_UPDATED_EVENT, getAiSettings } from 'services/api';
+import { AiSettingsType } from 'types';
+
+export function useAiFeatureEnabled(defaultEnabled = true): boolean {
+  const [enabled, setEnabled] = useState(false);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    void getAiSettings()
+      .then((settings) => {
+        if (isMounted) setEnabled(settings.enabled !== false);
+      })
+      .catch(() => {
+        if (isMounted) setEnabled(defaultEnabled);
+      });
+
+    const onSettingsUpdated = (event: Event) => {
+      const settingsEvent = event as CustomEvent<AiSettingsType>;
+      if (settingsEvent.detail) {
+        setEnabled(settingsEvent.detail.enabled !== false);
+      }
+    };
+
+    window.addEventListener(AI_SETTINGS_UPDATED_EVENT, onSettingsUpdated);
+
+    return () => {
+      isMounted = false;
+      window.removeEventListener(AI_SETTINGS_UPDATED_EVENT, onSettingsUpdated);
+    };
+  }, [defaultEnabled]);
+
+  return enabled;
+}

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -1,12 +1,168 @@
 import { runInAction } from 'mobx';
 
-import { ConversationAssetType, DefinitionsType, FileSystemItemType, QuickLinkType, ColourConfigType } from 'types';
+import {
+  AiDraftArtifactResultType,
+  AiDraftRequestType,
+  AiDraftRunResultType,
+  AiModelCatalogResultType,
+  AiModelOptionType,
+  AiSettingsType,
+  AiWorkspaceSettingsType,
+  ConversationAssetType,
+  ConversationValidationResultType,
+  DefinitionsType,
+  DependencyStatusType,
+  DirectoryItemType,
+  FileItemSystemType,
+  InputType,
+  InputTypeType,
+  InputValueType,
+  OperationDefinitionType,
+  PresetDefinitionType,
+  QuickLinkType,
+  TagDefinitionType,
+  ColourConfigType,
+} from 'types';
 import { consolidateSpeaker, rebuildNodeIndexes, removeAllOldFillerNodes } from 'utils/conversation-utils';
 
 import { get, post } from './rest';
 
 import { dataStore, defStore, nodeStore } from '../stores';
-import { JsonValue, fullConversationAssetMapping, lowercasePropertyNames, mapToType, reversedFullConversationAssetMapping } from './mappings/mapping';
+import { fullConversationAssetMapping, mapToType, reversedFullConversationAssetMapping } from './mappings/mapping';
+
+const AI_DEBUG_PREFIX = '[ConverseTek AI Settings]';
+export const AI_SETTINGS_UPDATED_EVENT = 'conversetek-ai-settings-updated';
+
+type DirectoryListingType = {
+  directories: DirectoryItemType[];
+  files: FileItemSystemType[];
+};
+
+type QuickLinksResponseType = Record<string, string>;
+
+// Backend wire DTOs mirror Json.NET's UpperCamelCase output and are mapped at this API boundary.
+type AiModelOptionResponseType = {
+  Slug?: string;
+  DisplayName?: string;
+  Description?: string;
+  DefaultReasoningLevel?: string;
+  Priority?: number;
+};
+
+type AiModelCatalogResponseType = {
+  Success?: boolean;
+  Error?: string | null;
+  Provider?: string;
+  DefaultModel?: string;
+  FromCache?: boolean;
+  Models?: AiModelOptionResponseType[];
+};
+
+type AiWorkspaceSettingsResponseType = {
+  WorkingDirectory?: string;
+  ContextPaths?: string[];
+  HouseStyleNotes?: string;
+  DefaultCampaignBrief?: string;
+};
+
+type AiSettingsResponseType = {
+  Enabled?: boolean | null;
+  SelectedProvider?: string;
+  CodexCommand?: string;
+  CodexModel?: string;
+  CodexProfile?: string;
+  TimeoutSeconds?: number;
+  ModelCatalogs?: Record<string, AiModelCatalogResponseType>;
+  Workspaces?: Record<string, AiWorkspaceSettingsResponseType>;
+};
+
+type AiDraftRunResponseType = {
+  Success: boolean;
+  Error: string | null;
+  Provider: string;
+  DiagnosticsDirectory: string;
+  RequestPath: string;
+  PromptPath: string;
+  OutputPath: string;
+  StdoutPath: string;
+  StderrPath: string;
+  DraftJson: string;
+};
+
+type AiDraftArtifactResponseType = {
+  Success: boolean;
+  Error: string | null;
+  Path: string;
+  Content: string;
+  Truncated: boolean;
+};
+
+type ConversationValidationResponseType = {
+  Success: boolean;
+  Error: string | null;
+};
+
+type FsDirectoryResponseType = {
+  Name: string;
+  Path: string;
+  HasChildren: boolean;
+  IsDirectory: boolean;
+};
+
+type FsFileResponseType = {
+  Name: string;
+  Path: string;
+  IsFile: boolean;
+};
+
+type DirectoryListingResponseType = {
+  directories: FsDirectoryResponseType[];
+  files: FsFileResponseType[];
+};
+
+type OperationInputValueResponseType = {
+  ViewLabel?: string;
+  Text?: string;
+  Value?: string | number;
+};
+
+type OperationInputResponseType = {
+  Label?: string;
+  Types?: InputTypeType[];
+  Tooltip?: string;
+  ViewLabel?: string;
+  Values?: OperationInputValueResponseType[];
+  DefaultValue?: string | number | null;
+};
+
+type OperationDefinitionResponseType = {
+  Key?: string;
+  Label?: string;
+  View?: OperationDefinitionType['view'];
+  Scope?: OperationDefinitionType['scope'];
+  Category?: OperationDefinitionType['category'];
+  Tooltip?: string;
+  Inputs?: OperationInputResponseType[];
+};
+
+type PresetDefinitionResponseType = {
+  Key?: string;
+  Label?: string;
+  Type?: PresetDefinitionType['type'];
+  Values?: Record<string, string | number | boolean | null>;
+};
+
+type TagDefinitionResponseType = {
+  Scope?: string | null;
+  Type?: string;
+  Tags?: string[];
+};
+
+type DefinitionsResponseType = {
+  operations: OperationDefinitionResponseType[];
+  presets: PresetDefinitionResponseType[];
+  tags: TagDefinitionResponseType[];
+};
 
 /*
  * CHROMELY DOESN'T SUPPORT PUTS SO PUTS AND DELETES ARE CURRENTLY POSTS WITH method DATA
@@ -27,8 +183,8 @@ export default function noop() {
  || STATUS METHODS ||
  ====================
 */
-export function getDependencyStatus(): Promise<any> {
-  return get('/dependency-status');
+export function getDependencyStatus(): Promise<DependencyStatusType> {
+  return get<DependencyStatusType>('/dependency-status');
 }
 
 /*
@@ -36,15 +192,15 @@ export function getDependencyStatus(): Promise<any> {
  || CONVERSATIONS METHODS ||
  ===========================
 */
-export function getConversations(): Promise<any> {
-  return get('/conversations').then((conversations: object[]): ConversationAssetType[] => {
+export function getConversations(): Promise<ConversationAssetType[]> {
+  return get<object[]>('/conversations').then((conversations): ConversationAssetType[] => {
     const typedConversations = conversations.map((conversation) => mapToType<ConversationAssetType>(conversation, fullConversationAssetMapping));
     dataStore.setConversations(typedConversations);
     return typedConversations;
   });
 }
 
-export function updateConversation(id: string, conversationAsset: ConversationAssetType): Promise<any> {
+export function updateConversation(id: string, conversationAsset: ConversationAssetType): Promise<ConversationAssetType[]> {
   runInAction(() => {
     consolidateSpeaker(conversationAsset);
     removeAllOldFillerNodes(conversationAsset); // This only exists to fix old conversations pre-v1.4
@@ -58,8 +214,8 @@ export function updateConversation(id: string, conversationAsset: ConversationAs
 
   const apiMappedConversation = mapToType<object>(conversationAsset, reversedFullConversationAssetMapping);
 
-  return post('/conversations/put', { id }, { method: 'PUT', conversationAsset: apiMappedConversation }).then(
-    (conversations: object[]): ConversationAssetType[] => {
+  return post<object[]>('/conversations/put', { id }, { method: 'PUT', conversationAsset: apiMappedConversation }).then(
+    (conversations): ConversationAssetType[] => {
       const typedConversations = conversations.map((conversation) => mapToType<ConversationAssetType>(conversation, fullConversationAssetMapping));
       dataStore.setConversations(typedConversations);
       dataStore.setConversationDirty(false);
@@ -68,7 +224,7 @@ export function updateConversation(id: string, conversationAsset: ConversationAs
   );
 }
 
-export function exportConversation(id: string, conversationAsset: ConversationAssetType): Promise<any> {
+export function exportConversation(id: string, conversationAsset: ConversationAssetType): Promise<unknown> {
   runInAction(() => {
     consolidateSpeaker(conversationAsset);
     removeAllOldFillerNodes(conversationAsset); // This only exists to fix old conversations pre-v1.4
@@ -85,7 +241,7 @@ export function exportConversation(id: string, conversationAsset: ConversationAs
   return post('/conversations/export', { id }, { method: 'PUT', conversationAsset: apiMappedConversation });
 }
 
-export function exportAllConversations(id: string, conversationAsset: ConversationAssetType | null): Promise<any> {
+export function exportAllConversations(id: string, conversationAsset: ConversationAssetType | null): Promise<unknown> {
   if (conversationAsset) {
     runInAction(() => {
       consolidateSpeaker(conversationAsset);
@@ -102,14 +258,272 @@ export function exportAllConversations(id: string, conversationAsset: Conversati
   return post('/conversations/export-all', { id }, { method: 'PUT', conversationAsset });
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function importConversation(path: string): Promise<any> {
+export function importConversation(path: string): Promise<unknown> {
   dataStore.clearActiveConversation();
   return post('/conversations/import', { path });
 }
 
-export function deleteConversation(path: string): Promise<any> {
+export function deleteConversation(path: string): Promise<unknown> {
   return post('/conversations/delete', { path });
+}
+
+function normaliseAiModelOption(model: AiModelOptionResponseType): AiModelOptionType {
+  return {
+    slug: model.Slug ?? '',
+    displayName: model.DisplayName ?? '',
+    description: model.Description ?? '',
+    defaultReasoningLevel: model.DefaultReasoningLevel ?? '',
+    priority: model.Priority ?? 0,
+  };
+}
+
+function normaliseAiModelCatalog(source: AiModelCatalogResponseType): AiModelCatalogResultType {
+  const rawModels = source.Models ?? [];
+
+  return {
+    success: source.Success ?? false,
+    error: source.Error ?? '',
+    provider: source.Provider ?? '',
+    defaultModel: source.DefaultModel ?? '',
+    fromCache: source.FromCache ?? false,
+    models: rawModels.map(normaliseAiModelOption),
+  };
+}
+
+function normaliseAiWorkspaceSettings(source: AiWorkspaceSettingsResponseType): AiWorkspaceSettingsType {
+  return {
+    workingDirectory: source.WorkingDirectory ?? '',
+    contextPaths: source.ContextPaths ?? [],
+    houseStyleNotes: source.HouseStyleNotes ?? '',
+    defaultCampaignBrief: source.DefaultCampaignBrief ?? '',
+  };
+}
+
+function normaliseAiSettings(source: AiSettingsResponseType): AiSettingsType {
+  const rawModelCatalogs = source.ModelCatalogs ?? {};
+  const rawWorkspaces = source.Workspaces ?? {};
+  const modelCatalogs: Record<string, AiModelCatalogResultType> = {};
+  const workspaces: Record<string, AiWorkspaceSettingsType> = {};
+
+  for (const [providerName, catalog] of Object.entries(rawModelCatalogs)) {
+    modelCatalogs[providerName] = normaliseAiModelCatalog(catalog);
+  }
+
+  for (const [workspaceKey, workspaceSettings] of Object.entries(rawWorkspaces)) {
+    workspaces[workspaceKey] = normaliseAiWorkspaceSettings(workspaceSettings);
+  }
+
+  const settings = {
+    enabled: source.Enabled ?? true,
+    selectedProvider: source.SelectedProvider ?? 'codex',
+    codexCommand: source.CodexCommand ?? 'codex',
+    codexModel: source.CodexModel ?? '',
+    codexProfile: source.CodexProfile ?? '',
+    timeoutSeconds: source.TimeoutSeconds ?? 300,
+    modelCatalogs,
+    workspaces,
+  };
+
+  console.log(`${AI_DEBUG_PREFIX} normaliseAiSettings`, {
+    rawSelectedProvider: source.SelectedProvider,
+    rawEnabled: source.Enabled,
+    rawCodexModel: source.CodexModel,
+    normalisedEnabled: settings.enabled,
+    normalisedSelectedProvider: settings.selectedProvider,
+    normalisedCodexModel: settings.codexModel,
+    modelCatalogKeys: Object.keys(settings.modelCatalogs),
+    workspaceKeys: Object.keys(settings.workspaces),
+    rawKeys: Object.keys(source),
+  });
+
+  return settings;
+}
+
+function notifyAiSettingsUpdated(settings: AiSettingsType): AiSettingsType {
+  window.dispatchEvent(new CustomEvent<AiSettingsType>(AI_SETTINGS_UPDATED_EVENT, { detail: settings }));
+  return settings;
+}
+
+function normaliseAiDraftRunResult(result: AiDraftRunResponseType): AiDraftRunResultType {
+  return {
+    success: result.Success,
+    error: result.Error ?? '',
+    provider: result.Provider,
+    diagnosticsDirectory: result.DiagnosticsDirectory,
+    requestPath: result.RequestPath,
+    promptPath: result.PromptPath,
+    outputPath: result.OutputPath,
+    stdoutPath: result.StdoutPath,
+    stderrPath: result.StderrPath,
+    draftJson: result.DraftJson,
+  };
+}
+
+function normaliseAiDraftArtifact(result: AiDraftArtifactResponseType): AiDraftArtifactResultType {
+  return {
+    success: result.Success,
+    error: result.Error ?? '',
+    path: result.Path,
+    content: result.Content,
+    truncated: result.Truncated,
+  };
+}
+
+function normaliseConversationValidation(result: ConversationValidationResponseType): ConversationValidationResultType {
+  return {
+    success: result.Success,
+    error: result.Error ?? '',
+  };
+}
+
+function normaliseDirectory(directory: FsDirectoryResponseType): DirectoryItemType {
+  return {
+    name: directory.Name,
+    path: directory.Path,
+    isDirectory: true,
+    isFile: false,
+    hasChildren: directory.HasChildren,
+    isQuickLink: false,
+  };
+}
+
+function normaliseFile(file: FsFileResponseType): FileItemSystemType {
+  return {
+    name: file.Name,
+    path: file.Path,
+    isDirectory: false,
+    isFile: true,
+  };
+}
+
+function normaliseInputValue(value: OperationInputValueResponseType): InputValueType {
+  return {
+    viewLabel: value.ViewLabel,
+    text: value.Text ?? '',
+    value: value.Value ?? '',
+  };
+}
+
+function normaliseOperationInput(input: OperationInputResponseType): InputType {
+  return {
+    label: input.Label ?? '',
+    types: input.Types ?? [],
+    tooltip: input.Tooltip,
+    viewLabel: input.ViewLabel,
+    values: input.Values?.map(normaliseInputValue),
+    defaultValue: input.DefaultValue ?? null,
+  };
+}
+
+function normaliseOperationDefinition(definition: OperationDefinitionResponseType): OperationDefinitionType {
+  return {
+    key: definition.Key ?? '',
+    label: definition.Label ?? '',
+    view: definition.View ?? [],
+    scope: definition.Scope ?? 'action',
+    category: definition.Category ?? 'primary',
+    tooltip: definition.Tooltip ?? '',
+    inputs: (definition.Inputs ?? []).map(normaliseOperationInput),
+  };
+}
+
+function normalisePresetDefinition(definition: PresetDefinitionResponseType): PresetDefinitionType {
+  const values = definition.Values ?? {};
+  const normalisedValues: Record<string, string> = {};
+
+  for (const [key, value] of Object.entries(values)) {
+    normalisedValues[key] = value == null ? '' : String(value);
+  }
+
+  return {
+    key: definition.Key ?? '',
+    label: definition.Label ?? '',
+    type: definition.Type ?? 'int',
+    values: normalisedValues,
+  };
+}
+
+function normaliseTagDefinition(definition: TagDefinitionResponseType): TagDefinitionType {
+  return {
+    scope: definition.Scope ?? null,
+    type: definition.Type,
+    tags: definition.Tags ?? [],
+  };
+}
+
+function normaliseDefinitions(definitions: DefinitionsResponseType): DefinitionsType {
+  return {
+    operations: definitions.operations.map(normaliseOperationDefinition),
+    presets: definitions.presets.map(normalisePresetDefinition),
+    tags: definitions.tags.map(normaliseTagDefinition),
+  };
+}
+
+export function getAiSettings(): Promise<AiSettingsType> {
+  return get<AiSettingsResponseType>('/ai/settings/current').then((settings) => {
+    console.log(`${AI_DEBUG_PREFIX} getAiSettings raw response`, settings);
+    return normaliseAiSettings(settings);
+  });
+}
+
+export function saveAiSettings(settings: AiSettingsType): Promise<AiSettingsType> {
+  console.log(`${AI_DEBUG_PREFIX} saveAiSettings request`, {
+    selectedProvider: settings.selectedProvider,
+    codexModel: settings.codexModel,
+    modelCatalogKeys: Object.keys(settings.modelCatalogs || {}),
+  });
+
+  return post<AiSettingsResponseType>('/ai/settings', {}, { settings }).then((updatedSettings) => {
+    console.log(`${AI_DEBUG_PREFIX} saveAiSettings raw response`, updatedSettings);
+    return notifyAiSettingsUpdated(normaliseAiSettings(updatedSettings));
+  });
+}
+
+export function saveAiWorkspaceSettings(workspaceSettings: AiWorkspaceSettingsType): Promise<AiSettingsType> {
+  console.log(`${AI_DEBUG_PREFIX} saveAiWorkspaceSettings request`, {
+    workingDirectory: workspaceSettings.workingDirectory,
+    contextPathCount: workspaceSettings.contextPaths.length,
+  });
+
+  return post<AiSettingsResponseType>('/ai/settings', {}, { workspaceSettings }).then((updatedSettings) => {
+    console.log(`${AI_DEBUG_PREFIX} saveAiWorkspaceSettings raw response`, updatedSettings);
+    return notifyAiSettingsUpdated(normaliseAiSettings(updatedSettings));
+  });
+}
+
+export function createAiDraft(request: AiDraftRequestType): Promise<AiDraftRunResultType> {
+  return post<AiDraftRunResponseType>('/ai/draft', {}, { request }).then(normaliseAiDraftRunResult);
+}
+
+export function getAiDraftArtifact(path: string): Promise<AiDraftArtifactResultType> {
+  return post<AiDraftArtifactResponseType>('/ai/draft-artifact', {}, { path }).then(normaliseAiDraftArtifact);
+}
+
+export function getAiModels(settings: AiSettingsType, forceRefresh = false): Promise<AiModelCatalogResultType> {
+  console.log(`${AI_DEBUG_PREFIX} getAiModels request`, {
+    selectedProvider: settings.selectedProvider,
+    codexModel: settings.codexModel,
+    forceRefresh,
+  });
+
+  return post<AiModelCatalogResponseType>('/ai/models', {}, { settings, forceRefresh }).then((result) => {
+    const catalog = normaliseAiModelCatalog(result);
+    console.log(`${AI_DEBUG_PREFIX} getAiModels response`, {
+      provider: catalog.provider,
+      success: catalog.success,
+      fromCache: catalog.fromCache,
+      modelCount: catalog.models.length,
+      modelSlugs: catalog.models.map((model) => model.slug),
+    });
+    return catalog;
+  });
+}
+
+export function validateConversationRoundTrip(conversationAsset: ConversationAssetType): Promise<ConversationValidationResultType> {
+  const apiMappedConversation = mapToType<object>(conversationAsset, reversedFullConversationAssetMapping);
+  return post<ConversationValidationResponseType>('/ai/validate-conversation', {}, { conversationAsset: apiMappedConversation }).then(
+    normaliseConversationValidation,
+  );
 }
 
 /*
@@ -117,16 +531,19 @@ export function deleteConversation(path: string): Promise<any> {
  || FILE SYSTEM METHODS ||
  =========================
 */
-export function getRootDrives(): Promise<any> {
-  return get('/filesystem').then((directories: JsonValue): FileSystemItemType[] => lowercasePropertyNames(directories, true) as FileSystemItemType[]);
+export function getRootDrives(): Promise<DirectoryItemType[]> {
+  return get<FsDirectoryResponseType[]>('/filesystem').then((directories): DirectoryItemType[] => directories.map(normaliseDirectory));
 }
 
-export function getDirectories(path: string, includeFiles = false): Promise<any> {
-  return get('/directories', { path, includeFiles }).then((directories: JsonValue) => lowercasePropertyNames(directories, true));
+export function getDirectories(path: string, includeFiles = false, fileExtensions: string[] = []): Promise<DirectoryListingType> {
+  return get<DirectoryListingResponseType>('/directories', { path, includeFiles, fileExtensions }).then((result): DirectoryListingType => ({
+    directories: result.directories.map(normaliseDirectory),
+    files: result.files.map(normaliseFile),
+  }));
 }
 
-export function getQuickLinks() {
-  return get('/quicklinks').then((quickLinks: [string, string]) => {
+export function getQuickLinks(): Promise<QuickLinkType[]> {
+  return get<QuickLinksResponseType>('/quicklinks').then((quickLinks) => {
     const entries: QuickLinkType[] = [];
     for (const [key, value] of Object.entries(quickLinks)) {
       entries.push({ title: key, path: value } as QuickLinkType);
@@ -135,10 +552,10 @@ export function getQuickLinks() {
   });
 }
 
-export function addQuickLink(title: string, path: string) {
+export function addQuickLink(title: string, path: string): Promise<QuickLinkType[]> {
   const modifiedPath = path.replaceAll('\\', '/');
 
-  return post('/add-quicklink', { title, path: modifiedPath }).then((quickLinks: [string, string]) => {
+  return post<QuickLinksResponseType>('/add-quicklink', { title, path: modifiedPath }).then((quickLinks) => {
     const entries: QuickLinkType[] = [];
     for (const [key, value] of Object.entries(quickLinks)) {
       entries.push({ title: key, path: value } as QuickLinkType);
@@ -147,9 +564,9 @@ export function addQuickLink(title: string, path: string) {
   });
 }
 
-export function removeQuickLink(title: string, path: string) {
+export function removeQuickLink(title: string, path: string): Promise<QuickLinkType[]> {
   const modifiedPath = path.replaceAll('\\', '/');
-  return post('/remove-quicklink', { title, path: modifiedPath }).then((quickLinks: [string, string]) => {
+  return post<QuickLinksResponseType>('/remove-quicklink', { title, path: modifiedPath }).then((quickLinks) => {
     const entries: QuickLinkType[] = [];
     for (const [key, value] of Object.entries(quickLinks)) {
       entries.push({ title: key, path: value } as QuickLinkType);
@@ -158,13 +575,13 @@ export function removeQuickLink(title: string, path: string) {
   });
 }
 
-export function getColourConfig() {
-  return get('/colour-config').then((colourConfig: ColourConfigType) => {
+export function getColourConfig(): Promise<void> {
+  return get<ColourConfigType>('/colour-config').then((colourConfig) => {
     dataStore.setColourConfig(colourConfig);
   });
 }
 
-export function saveWorkingDirectory(path: string, name: string) {
+export function saveWorkingDirectory(path: string, name: string): Promise<unknown> {
   dataStore.setWorkingDirectory(path, name);
   return post('/working-directory', { path });
 }
@@ -174,9 +591,9 @@ export function saveWorkingDirectory(path: string, name: string) {
  || DEFINITIONS METHODS ||
  =========================
 */
-export function getDefinitions(): Promise<any> {
-  return get('/definitions').then((definitions: JsonValue): DefinitionsType => {
-    const typedDefinitions = lowercasePropertyNames(definitions, true) as DefinitionsType;
+export function getDefinitions(): Promise<DefinitionsType> {
+  return get<DefinitionsResponseType>('/definitions').then((definitions): DefinitionsType => {
+    const typedDefinitions = normaliseDefinitions(definitions);
     defStore.setDefinitions(typedDefinitions);
     return typedDefinitions;
   });

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -1,6 +1,7 @@
 import { runInAction } from 'mobx';
 
 import {
+  AiCastPersonalityType,
   AiDraftArtifactResultType,
   AiDraftRequestType,
   AiDraftRunResultType,
@@ -63,6 +64,17 @@ type AiWorkspaceSettingsResponseType = {
   ContextPaths?: string[];
   HouseStyleNotes?: string;
   DefaultCampaignBrief?: string;
+  CastPersonalities?: AiCastPersonalityResponseType[];
+};
+
+type AiCastPersonalityResponseType = {
+  Id?: string;
+  Label?: string;
+  CastIds?: string[];
+  SpeakerIds?: string[];
+  Rules?: string;
+  Enabled?: boolean | null;
+  DefaultKey?: string;
 };
 
 type AiSettingsResponseType = {
@@ -74,6 +86,7 @@ type AiSettingsResponseType = {
   TimeoutSeconds?: number;
   ModelCatalogs?: Record<string, AiModelCatalogResponseType>;
   Workspaces?: Record<string, AiWorkspaceSettingsResponseType>;
+  DefaultCastPersonalities?: AiCastPersonalityResponseType[];
 };
 
 type AiDraftRunResponseType = {
@@ -290,12 +303,25 @@ function normaliseAiModelCatalog(source: AiModelCatalogResponseType): AiModelCat
   };
 }
 
+function normaliseAiCastPersonality(source: AiCastPersonalityResponseType): AiCastPersonalityType {
+  return {
+    id: source.Id ?? '',
+    label: source.Label ?? '',
+    castIds: source.CastIds ?? [],
+    speakerIds: source.SpeakerIds ?? [],
+    rules: source.Rules ?? '',
+    enabled: source.Enabled ?? true,
+    defaultKey: source.DefaultKey ?? '',
+  };
+}
+
 function normaliseAiWorkspaceSettings(source: AiWorkspaceSettingsResponseType): AiWorkspaceSettingsType {
   return {
     workingDirectory: source.WorkingDirectory ?? '',
     contextPaths: source.ContextPaths ?? [],
     houseStyleNotes: source.HouseStyleNotes ?? '',
     defaultCampaignBrief: source.DefaultCampaignBrief ?? '',
+    castPersonalities: (source.CastPersonalities ?? []).map(normaliseAiCastPersonality),
   };
 }
 
@@ -322,6 +348,7 @@ function normaliseAiSettings(source: AiSettingsResponseType): AiSettingsType {
     timeoutSeconds: source.TimeoutSeconds ?? 300,
     modelCatalogs,
     workspaces,
+    defaultCastPersonalities: (source.DefaultCastPersonalities ?? []).map(normaliseAiCastPersonality),
   };
 
   console.log(`${AI_DEBUG_PREFIX} normaliseAiSettings`, {

--- a/app/src/services/mappings/mapping.ts
+++ b/app/src/services/mappings/mapping.ts
@@ -1,11 +1,7 @@
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/no-unsafe-return */
-/* eslint-disable @typescript-eslint/no-unsafe-argument */
-/* eslint-disable @typescript-eslint/no-explicit-any */
 export type JsonValue = string | number | boolean | JsonObject | JsonArray | null;
 export type JsonObject = { [key: string]: JsonValue };
 export type JsonArray = JsonValue[];
+type MappableObject = Record<string, unknown>;
 
 type PropertyMapping = {
   [apiProperty: string]: string;
@@ -52,32 +48,47 @@ export const reversedFullConversationAssetMapping = reverseMapping(fullConversat
 
 // PROCESSING
 
-export function lowercasePropertyNames(obj: JsonValue, firstCharacterLower = false): JsonValue {
+function toJsonValue(value: unknown): JsonValue {
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean' || value === null) {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => toJsonValue(item));
+  }
+
+  if (isObject(value)) {
+    const jsonObject: JsonObject = {};
+    for (const [key, nestedValue] of Object.entries(value)) {
+      jsonObject[key] = toJsonValue(nestedValue);
+    }
+    return jsonObject;
+  }
+
+  return null;
+}
+
+export function lowercasePropertyNames(obj: unknown, firstCharacterLower = false): JsonValue {
   if (Array.isArray(obj)) {
     return obj.map((item) => lowercasePropertyNames(item, firstCharacterLower));
   } else if (typeof obj === 'object' && obj !== null) {
     const newObj: JsonObject = {};
 
-    for (const key in obj) {
-      if (Object.prototype.hasOwnProperty.call(obj, key)) {
-        newObj[firstCharacterLower ? `${key[0].toLowerCase()}${key.substring(1)}` : key.toLowerCase()] = lowercasePropertyNames(
-          obj[key],
-          firstCharacterLower,
-        );
-      }
+    for (const [key, value] of Object.entries(obj)) {
+      newObj[firstCharacterLower ? `${key[0].toLowerCase()}${key.substring(1)}` : key.toLowerCase()] = lowercasePropertyNames(value, firstCharacterLower);
     }
 
     return newObj;
   } else {
-    return obj;
+    return toJsonValue(obj);
   }
 }
 
-function isObject(value: any): boolean {
+function isObject(value: unknown): value is MappableObject {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 
-function mapArray<T>(arr: any[], mapping: PropertyMapping): any[] {
+function mapArray(arr: unknown[], mapping: PropertyMapping): unknown[] {
   return arr.map((item) => {
     if (isObject(item)) {
       return mapToType(item, mapping);
@@ -89,17 +100,18 @@ function mapArray<T>(arr: any[], mapping: PropertyMapping): any[] {
 }
 
 export function mapToType<T>(obj: object, mapping: PropertyMapping): T {
-  const result: Partial<T> = {};
+  const source = obj as MappableObject;
+  const result: MappableObject = {};
   for (const key in obj) {
     const newKey: string = mapping[key] || key;
-    const value = (obj as any)[key];
+    const value = source[key];
 
     if (isObject(value)) {
-      (result as any)[newKey] = mapToType(value, mapping);
+      result[newKey] = mapToType(value, mapping);
     } else if (Array.isArray(value)) {
-      (result as any)[newKey] = mapArray(value, mapping);
+      result[newKey] = mapArray(value, mapping);
     } else {
-      (result as any)[newKey] = value;
+      result[newKey] = value;
     }
   }
   return result as T;

--- a/app/src/services/rest.ts
+++ b/app/src/services/rest.ts
@@ -1,7 +1,6 @@
 type ResolveType<T> = (value: T | PromiseLike<T>) => void;
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type RejectType = (reason?: any) => void;
+type RejectType = (reason?: unknown) => void;
 
 type Response = {
   ResponseText: string;
@@ -36,17 +35,15 @@ export function infoTemp() {
  * request - a Json object
  * response - callback response method
  */
-export function get<T>(url: string, parameters: object | null = null): Promise<any> {
+export function get<T = unknown>(url: string, parameters: object | null = null): Promise<T> {
   return new Promise<T>((resolve, reject) => {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     boundControllerAsync.getJson(url, parameters, (response: Response) => promiseSupportedCallback<T>(response, resolve, reject));
   });
 }
 
-export function post<T>(url: string, parameters: object, postData?: object): Promise<any> {
+export function post<T = unknown>(url: string, parameters: object, postData?: object): Promise<T> {
   const postJsonData = JSON.stringify(postData);
   return new Promise<T>((resolve, reject) => {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     boundControllerAsync.postJson(url, parameters, postJsonData, (response: Response) => promiseSupportedCallback<T>(response, resolve, reject));
   });
 }

--- a/app/src/stores/defStore/def-store.ts
+++ b/app/src/stores/defStore/def-store.ts
@@ -236,6 +236,8 @@ class DefStore {
 
   getRawArgType(arg: OperationArgType): 'operation' | 'string' | 'float' | 'int' {
     const { intValue, boolValue, floatValue, stringValue, callValue, variableRefValue } = arg;
+    void boolValue;
+    void variableRefValue;
 
     // Use same logic BT uses
     if (callValue) return 'operation';
@@ -248,6 +250,8 @@ class DefStore {
     if (arg == null) return { type: null, value: null };
 
     const { intValue, boolValue, floatValue, stringValue, callValue, variableRefValue, type } = arg;
+    void boolValue;
+    void variableRefValue;
 
     if (type) {
       if (type === 'operation') return { type, value: callValue };
@@ -267,7 +271,7 @@ class DefStore {
       callValue: null,
       floatValue: type === 'float' && defaultValue != null ? Number(defaultValue) : 0,
       intValue: type === 'int' && defaultValue != null ? Number(defaultValue) : 0,
-      stringValue: type === 'string' && defaultValue != null ? defaultValue : '',
+      stringValue: type === 'string' && defaultValue != null ? String(defaultValue) : '',
       type,
       variableRefValue: null,
     };
@@ -405,7 +409,7 @@ class DefStore {
       arg.callValue = this.setOperation(opLogic, opLogic.functionName);
     } else if (types.includes('string')) {
       arg.type = 'string';
-      if (defaultValue != null) arg.stringValue = defaultValue;
+      if (defaultValue != null) arg.stringValue = String(defaultValue);
     } else if (types.includes('float')) {
       arg.type = 'float';
       if (defaultValue != null) arg.floatValue = Number(defaultValue);

--- a/app/src/stores/modalStore/modal-store.tsx
+++ b/app/src/stores/modalStore/modal-store.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable function-paren-newline */
 import React, { MouseEvent, ElementType } from 'react';
 import { observable, action, makeObservable } from 'mobx';
-import defer from 'lodash.defer';
 import { ButtonType } from 'antd/lib/button';
 
 export type OnOkType = ((event: MouseEvent<HTMLElement>, value?: string) => void) | null;
@@ -41,6 +40,7 @@ type ModalOptions = {
 class ModalStore {
   modals = new Map<string, ElementType | JSX.Element>();
   options = new Map<string, ModalOptions>();
+  private modalVersion = 0;
 
   constructor() {
     makeObservable(this, {
@@ -71,7 +71,8 @@ class ModalStore {
   }
 
   setModelContent(ModalContent: ElementType, props = {}, globalModalId: string, show = true): void {
-    this.modals.set(globalModalId, <ModalContent globalModalId={globalModalId} {...props} />);
+    this.modalVersion += 1;
+    this.modals.set(globalModalId, <ModalContent key={`${globalModalId}-${this.modalVersion}`} globalModalId={globalModalId} {...props} />);
 
     const options: ModalOptions = {
       props,

--- a/app/src/stores/nodeStore/node-store.ts
+++ b/app/src/stores/nodeStore/node-store.ts
@@ -49,6 +49,7 @@ class NodeStore {
   maxTreeHorizontalNodePosition = 0;
   dirtyActiveNode = false;
   rebuild = false;
+  speakerRevision = 0;
 
   constructor() {
     makeObservable(this, {
@@ -62,6 +63,7 @@ class NodeStore {
       expandFromCoreToNodeId: observable,
       isolateOnNodeId: observable,
       rebuild: observable,
+      speakerRevision: observable,
       maxTreeHorizontalNodePosition: observable,
       setRebuild: action,
       init: action,
@@ -86,6 +88,7 @@ class NodeStore {
       setPromptNodeSpeakerType: action,
       setPromptNodeSourceInSceneId: action,
       setPromptNodeSpeakerId: action,
+      bumpSpeakerRevision: action,
       setNodeActions: action,
       removeNodeAction: action,
       addNodeAction: action,
@@ -702,6 +705,7 @@ class NodeStore {
     if (value === 'speakerId') node.sourceInSceneRef = null;
 
     dataStore.setConversationDirty(true);
+    this.bumpSpeakerRevision();
   }
 
   setPromptNodeSourceInSceneId(node: PromptNodeType, id: string): void {
@@ -712,12 +716,22 @@ class NodeStore {
     }
 
     dataStore.setConversationDirty(true);
+    this.bumpSpeakerRevision();
   }
 
   setPromptNodeSpeakerId(node: PromptNodeType, id: string): void {
     node.speakerOverrideId = id;
     node.sourceInSceneRef = null;
     dataStore.setConversationDirty(true);
+    this.bumpSpeakerRevision();
+  }
+
+  bumpSpeakerRevision(): void {
+    this.speakerRevision += 1;
+  }
+
+  getSpeakerRevision(): number {
+    return this.speakerRevision;
   }
 
   setNodeActions(node: PromptNodeType | ElementNodeType, actions: OperationCallType[] | null): void {

--- a/app/src/types/AiDraftType.ts
+++ b/app/src/types/AiDraftType.ts
@@ -1,0 +1,149 @@
+import { ConversationAssetType } from './ConversationAssetType';
+import { ElementNodeType } from './ElementNodeType';
+import { PromptNodeType } from './PromptNodeType';
+
+export type AiProviderName = 'codex' | 'claudecode' | string;
+
+export type AiWorkspaceSettingsType = {
+  workingDirectory: string;
+  contextPaths: string[];
+  houseStyleNotes: string;
+  defaultCampaignBrief: string;
+};
+
+export type AiSettingsType = {
+  enabled: boolean;
+  selectedProvider: AiProviderName;
+  codexCommand: string;
+  codexModel: string;
+  codexProfile: string;
+  timeoutSeconds: number;
+  modelCatalogs: Record<string, AiModelCatalogResultType>;
+  workspaces: Record<string, AiWorkspaceSettingsType>;
+};
+
+export type AiDraftModeType = 'fullConversation' | 'nodeSuggestion' | 'branchExpansion';
+
+export type AiDraftArgType = {
+  type: 'string' | 'int' | 'float' | 'bool';
+  value: string | number | boolean | null;
+};
+
+export type AiDraftOperationIntentType = {
+  functionName: string;
+  args: AiDraftArgType[];
+  note: string;
+};
+
+export type AiDraftSpeakerType = {
+  type: 'castId' | 'speakerId' | 'none';
+  id: string;
+};
+
+export type AiDraftChoiceType = {
+  text: string;
+  targetKey: string;
+  endsConversation: boolean;
+  auxiliaryLink: boolean;
+  conditions: AiDraftOperationIntentType[];
+  actions: AiDraftOperationIntentType[];
+};
+
+export type AiDraftNodeType = {
+  key: string;
+  speaker: AiDraftSpeakerType;
+  text: string;
+  choices: AiDraftChoiceType[];
+  actions: AiDraftOperationIntentType[];
+};
+
+export type AiConversationDraftType = {
+  version: number;
+  mode: AiDraftModeType;
+  title: string;
+  summary: string;
+  cast: {
+    id: string;
+    label: string;
+    role: string;
+  }[];
+  roots: AiDraftChoiceType[];
+  nodes: AiDraftNodeType[];
+  warnings: string[];
+};
+
+export type AiDraftRequestType = {
+  mode: AiDraftModeType;
+  brief: string;
+  workingDirectory: string;
+  conversationJson: string;
+  selectedNodeJson: string;
+  definitionsJson: string;
+};
+
+export type AiDraftRunResultType = {
+  success: boolean;
+  error: string;
+  provider: string;
+  diagnosticsDirectory: string;
+  requestPath: string;
+  promptPath: string;
+  outputPath: string;
+  stdoutPath: string;
+  stderrPath: string;
+  draftJson: string;
+};
+
+export type AiDraftArtifactResultType = {
+  success: boolean;
+  error: string;
+  path: string;
+  content: string;
+  truncated: boolean;
+};
+
+export type AiModelOptionType = {
+  slug: string;
+  displayName: string;
+  description: string;
+  defaultReasoningLevel: string;
+  priority: number;
+};
+
+export type AiModelCatalogResultType = {
+  success: boolean;
+  error: string;
+  provider: string;
+  defaultModel: string;
+  fromCache: boolean;
+  models: AiModelOptionType[];
+};
+
+export type ConversationValidationResultType = {
+  success: boolean;
+  error: string;
+};
+
+export type AiDraftValidationResultType = {
+  errors: string[];
+  warnings: string[];
+};
+
+export type AiBranchExpansionPatchType = {
+  parentElementNode: ElementNodeType;
+  nodes: PromptNodeType[];
+};
+
+export type AiAcceptedDraftType =
+  | {
+      kind: 'fullConversation';
+      conversationAsset: ConversationAssetType;
+    }
+  | {
+      kind: 'nodeText';
+      text: string;
+    }
+  | {
+      kind: 'branchExpansion';
+      patch: AiBranchExpansionPatchType;
+    };

--- a/app/src/types/AiDraftType.ts
+++ b/app/src/types/AiDraftType.ts
@@ -42,6 +42,7 @@ export type AiDraftSpeakerType = {
 
 export type AiDraftChoiceType = {
   text: string;
+  comment?: string;
   targetKey: string;
   endsConversation: boolean;
   auxiliaryLink: boolean;
@@ -51,6 +52,7 @@ export type AiDraftChoiceType = {
 
 export type AiDraftNodeType = {
   key: string;
+  comment?: string;
   speaker: AiDraftSpeakerType;
   text: string;
   choices: AiDraftChoiceType[];

--- a/app/src/types/AiDraftType.ts
+++ b/app/src/types/AiDraftType.ts
@@ -9,6 +9,17 @@ export type AiWorkspaceSettingsType = {
   contextPaths: string[];
   houseStyleNotes: string;
   defaultCampaignBrief: string;
+  castPersonalities: AiCastPersonalityType[];
+};
+
+export type AiCastPersonalityType = {
+  id: string;
+  label: string;
+  castIds: string[];
+  speakerIds: string[];
+  rules: string;
+  enabled: boolean;
+  defaultKey: string;
 };
 
 export type AiSettingsType = {
@@ -20,6 +31,7 @@ export type AiSettingsType = {
   timeoutSeconds: number;
   modelCatalogs: Record<string, AiModelCatalogResultType>;
   workspaces: Record<string, AiWorkspaceSettingsType>;
+  defaultCastPersonalities: AiCastPersonalityType[];
 };
 
 export type AiDraftModeType = 'fullConversation' | 'nodeSuggestion' | 'branchExpansion';

--- a/app/src/types/ConverseTek.d.ts
+++ b/app/src/types/ConverseTek.d.ts
@@ -1,2 +1,11 @@
-declare const boundControllerAsync;
+type ChromelyBridgeResponse = {
+  ResponseText: string;
+};
+
+type BoundControllerAsyncType = {
+  getJson: (url: string, parameters: object | null, callback: (response: ChromelyBridgeResponse) => void) => void;
+  postJson: (url: string, parameters: object, postData: string | undefined, callback: (response: ChromelyBridgeResponse) => void) => void;
+};
+
+declare const boundControllerAsync: BoundControllerAsyncType;
 declare const __INITIAL_ROUTE_PATH__: string;

--- a/app/src/types/OperationDefinitionType.ts
+++ b/app/src/types/OperationDefinitionType.ts
@@ -3,7 +3,7 @@ type ViewType = 'label' | 'inputs' | 'result';
 export type InputTypeType = 'string' | 'int' | 'operation' | 'float' | 'bool';
 export const InputTypeTypes = ['string', 'int', 'operation', 'float', 'bool'];
 
-export type DefaultInputValueType = 'string' | 'number' | null;
+export type DefaultInputValueType = string | number | null;
 
 export type InputValueType = {
   viewLabel?: string;

--- a/app/src/types/TagDefinitionType.ts
+++ b/app/src/types/TagDefinitionType.ts
@@ -1,3 +1,5 @@
 export type TagDefinitionType = {
-  scope: null;
+  scope: string | null;
+  type?: string;
+  tags: string[];
 };

--- a/app/src/types/Vendor.d.ts
+++ b/app/src/types/Vendor.d.ts
@@ -1,5 +1,7 @@
 declare module 'react-sortable-tree';
 
+declare module '*.css';
+
 declare module '@ungap/structured-clone' {
   const structuredClone: <T>(input: T) => T;
   export = structuredClone;

--- a/app/src/types/index.ts
+++ b/app/src/types/index.ts
@@ -1,6 +1,7 @@
 export type { ClipboardType } from './ClipboardType';
 export type {
   AiAcceptedDraftType,
+  AiCastPersonalityType,
   AiDraftArtifactResultType,
   AiBranchExpansionPatchType,
   AiConversationDraftType,

--- a/app/src/types/index.ts
+++ b/app/src/types/index.ts
@@ -1,4 +1,22 @@
 export type { ClipboardType } from './ClipboardType';
+export type {
+  AiAcceptedDraftType,
+  AiDraftArtifactResultType,
+  AiBranchExpansionPatchType,
+  AiConversationDraftType,
+  AiDraftChoiceType,
+  AiDraftModeType,
+  AiDraftOperationIntentType,
+  AiDraftRequestType,
+  AiDraftRunResultType,
+  AiDraftValidationResultType,
+  AiModelCatalogResultType,
+  AiModelOptionType,
+  AiProviderName,
+  AiSettingsType,
+  AiWorkspaceSettingsType,
+  ConversationValidationResultType,
+} from './AiDraftType';
 export type { IdRef, ConversationAssetType } from './ConversationAssetType';
 export type { DefinitionsType } from './DefinitionsType';
 export type { ElementNodeType } from './ElementNodeType';

--- a/app/src/utils/__tests__/ai-artifact-utils.test.ts
+++ b/app/src/utils/__tests__/ai-artifact-utils.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatAiDraftArtifactContent } from 'utils/ai-artifact-utils';
+
+describe('AI artifact utilities', () => {
+  it('formats collapsed JSON responses', () => {
+    const result = formatAiDraftArtifactContent('{"title":"Routine Is A Lie","nodes":[{"key":"start","choices":[]}]}');
+
+    expect(result.wasFormatted).toBe(true);
+    expect(result.formattedContent).toContain('\n  "title": "Routine Is A Lie"');
+    expect(result.formattedContent).toContain('\n  "nodes": [');
+  });
+
+  it('expands embedded JSON strings inside prompt request blocks', () => {
+    const prompt = [
+      '# Prompt',
+      '',
+      'Request JSON:',
+      '```json',
+      '{"Request":{"Brief":"Test","ConversationJson":"{\\"conversation\\":{\\"uiName\\":\\"Dead Claim\\"}}"}}',
+      '```',
+    ].join('\n');
+
+    const result = formatAiDraftArtifactContent(prompt);
+
+    expect(result.wasFormatted).toBe(true);
+    expect(result.formattedContent).toContain('"ConversationJson": {');
+    expect(result.formattedContent).toContain('"uiName": "Dead Claim"');
+    expect(result.notes).toContain('Expanded embedded JSON strings inside the prompt request.');
+  });
+
+  it('keeps unparseable text unchanged', () => {
+    const content = 'Plain stdout log line';
+    const result = formatAiDraftArtifactContent(content);
+
+    expect(result.wasFormatted).toBe(false);
+    expect(result.formattedContent).toBe(content);
+  });
+});
+

--- a/app/src/utils/__tests__/ai-draft-utils.test.ts
+++ b/app/src/utils/__tests__/ai-draft-utils.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { AiConversationDraftType, ElementNodeType, OperationDefinitionType, PromptNodeType } from 'types';
+
+vi.mock('antd', () => ({
+  message: {
+    error: vi.fn(),
+    success: vi.fn(),
+    warning: vi.fn(),
+  },
+}));
+
+vi.stubGlobal('document', {
+  addEventListener: vi.fn(),
+  getElementsByTagName: vi.fn(() => []),
+});
+
+const operations: OperationDefinitionType[] = [
+  {
+    key: 'SetFlag',
+    label: 'Set Flag',
+    view: ['label'],
+    scope: 'action',
+    category: 'primary',
+    tooltip: '',
+    inputs: [{ label: 'Flag', types: ['string'] }],
+  },
+];
+
+function makeDraft(overrides: Partial<AiConversationDraftType> = {}): AiConversationDraftType {
+  return {
+    version: 1,
+    mode: 'fullConversation',
+    title: 'Dead Claim Briefing',
+    summary: 'Darius introduces the problem and gives the commander a choice.',
+    cast: [{ id: 'DariusDefault', label: 'Darius', role: 'XO' }],
+    roots: [
+      {
+        text: 'Open the briefing.',
+        targetKey: 'intro',
+        endsConversation: false,
+        auxiliaryLink: false,
+        conditions: [],
+        actions: [],
+      },
+    ],
+    nodes: [
+      {
+        key: 'intro',
+        speaker: { type: 'castId', id: 'DariusDefault' },
+        text: 'Commander, this contract has been dead for years, but someone just paid to exhume it.',
+        actions: [{ functionName: 'SetFlag', args: [{ type: 'string', value: 'dead_claim_intro' }], note: '' }],
+        choices: [
+          {
+            text: 'Keep talking.',
+            targetKey: 'followup',
+            endsConversation: false,
+            auxiliaryLink: false,
+            conditions: [],
+            actions: [],
+          },
+        ],
+      },
+      {
+        key: 'followup',
+        speaker: { type: 'castId', id: 'DariusDefault' },
+        text: 'I do not like the smell of it, but the money is real.',
+        actions: [],
+        choices: [
+          {
+            text: 'End briefing.',
+            targetKey: '',
+            endsConversation: true,
+            auxiliaryLink: false,
+            conditions: [],
+            actions: [],
+          },
+        ],
+      },
+    ],
+    warnings: [],
+    ...overrides,
+  };
+}
+
+describe('AI draft utilities', () => {
+  it('validates a branching draft with forward target references', async () => {
+    const { validateAiDraft } = await import('utils/ai-draft-utils');
+
+    const result = validateAiDraft(makeDraft(), operations, 'fullConversation');
+
+    expect(result.errors).toEqual([]);
+  });
+
+  it('flags duplicate draft keys before accepting', async () => {
+    const { validateAiDraft } = await import('utils/ai-draft-utils');
+    const draft = makeDraft({
+      nodes: [makeDraft().nodes[0], { ...makeDraft().nodes[1], key: 'intro' }],
+    });
+
+    const result = validateAiDraft(draft, operations, 'fullConversation');
+
+    expect(result.errors).toContain("Prompt node key 'intro' is duplicated.");
+  });
+
+  it('turns a full draft into a fresh conversation asset with resolved graph targets', async () => {
+    const { buildConversationAssetFromDraft } = await import('utils/ai-draft-utils');
+
+    const conversationAsset = buildConversationAssetFromDraft(makeDraft(), 'K:/Mods/DeadClaim/conversations');
+
+    expect(conversationAsset.conversation.uiName).toBe('Dead Claim Briefing');
+    expect(conversationAsset.conversation.roots[0].nextNodeIndex).toBe(0);
+    expect(conversationAsset.conversation.nodes[0].branches[0].nextNodeIndex).toBe(1);
+    expect(conversationAsset.conversation.nodes[1].branches[0].nextNodeIndex).toBe(-1);
+    expect(conversationAsset.conversation.nodes[0].actions?.ops?.[0].functionName).toBe('SetFlag');
+  });
+
+  it('builds a branch expansion patch without mutating the selected element node', async () => {
+    const { buildBranchExpansionPatch } = await import('utils/ai-draft-utils');
+    const root = {
+      type: 'root',
+      parentId: '0',
+      nextNodeIndex: -1,
+      responseText: 'Ask Darius.',
+      auxiliaryLink: false,
+      idRef: { id: 'root-id' },
+      conditions: null,
+      actions: null,
+      hideIfUnavailable: true,
+      onlyOnce: false,
+      inputBypass: false,
+      comment: '',
+    } as ElementNodeType;
+
+    const patch = buildBranchExpansionPatch(makeDraft({ mode: 'branchExpansion', roots: [] }), root);
+
+    expect(root.nextNodeIndex).toBe(-1);
+    expect(patch.parentElementNode.nextNodeIndex).toBe(patch.nodes[0].index);
+    expect(patch.nodes[0].parentId).toBe('root-id');
+  });
+
+  it('builds a branch expansion preview as a temporary conversation tree', async () => {
+    const { buildPreviewConversationAssetFromDraft } = await import('utils/ai-draft-utils');
+    const response = {
+      type: 'response',
+      parentId: 'parent-node',
+      nextNodeIndex: -1,
+      responseText: 'Ask Sumire for a signal check.',
+      auxiliaryLink: false,
+      idRef: { id: 'response-id' },
+      conditions: null,
+      actions: null,
+      hideIfUnavailable: true,
+      onlyOnce: false,
+      inputBypass: false,
+      comment: '',
+    } as ElementNodeType;
+
+    const preview = buildPreviewConversationAssetFromDraft(
+      makeDraft({ mode: 'branchExpansion', roots: [] }),
+      'branchExpansion',
+      'K:/Mods/DeadClaim/conversations',
+      response,
+    );
+
+    expect(preview?.conversation.roots[0].responseText).toBe('Ask Sumire for a signal check.');
+    expect(preview?.conversation.roots[0].nextNodeIndex).toBe(0);
+    expect(preview?.conversation.nodes[0].parentId).toBe(preview?.conversation.roots[0].idRef.id);
+  });
+
+  it('uses node text for prompt suggestions and response text for element suggestions', async () => {
+    const { getSuggestedNodeText } = await import('utils/ai-draft-utils');
+    const draft = makeDraft({ mode: 'nodeSuggestion' });
+    const prompt = { type: 'node' } as PromptNodeType;
+    const response = { type: 'response' } as ElementNodeType;
+
+    expect(getSuggestedNodeText(draft, prompt)).toBe(draft.nodes[0].text);
+    expect(getSuggestedNodeText(draft, response)).toBe(draft.roots[0].text);
+  });
+});

--- a/app/src/utils/__tests__/ai-draft-utils.test.ts
+++ b/app/src/utils/__tests__/ai-draft-utils.test.ts
@@ -114,6 +114,72 @@ describe('AI draft utilities', () => {
     expect(conversationAsset.conversation.nodes[0].actions?.ops?.[0].functionName).toBe('SetFlag');
   });
 
+  it('converts repeated full-draft targets into auxiliary links after the first structural parent', async () => {
+    const { buildConversationAssetFromDraft } = await import('utils/ai-draft-utils');
+    const draft = makeDraft({
+      nodes: [
+        {
+          ...makeDraft().nodes[0],
+          choices: [
+            {
+              text: 'Ask for the practical version.',
+              targetKey: 'followup',
+              endsConversation: false,
+              auxiliaryLink: false,
+              conditions: [],
+              actions: [],
+            },
+            {
+              text: 'Ask for the cautious version.',
+              targetKey: 'followup',
+              endsConversation: false,
+              auxiliaryLink: false,
+              conditions: [],
+              actions: [],
+            },
+          ],
+        },
+        makeDraft().nodes[1],
+      ],
+    });
+
+    const conversationAsset = buildConversationAssetFromDraft(draft, 'K:/Mods/DeadClaim/conversations');
+    const [firstBranch, secondBranch] = conversationAsset.conversation.nodes[0].branches;
+
+    expect(firstBranch.nextNodeIndex).toBe(1);
+    expect(firstBranch.auxiliaryLink).toBe(false);
+    expect(secondBranch.nextNodeIndex).toBe(1);
+    expect(secondBranch.auxiliaryLink).toBe(true);
+  });
+
+  it('converts backwards full-draft targets into auxiliary links to avoid rendering duplicate branches', async () => {
+    const { buildConversationAssetFromDraft } = await import('utils/ai-draft-utils');
+    const draft = makeDraft({
+      nodes: [
+        makeDraft().nodes[0],
+        {
+          ...makeDraft().nodes[1],
+          choices: [
+            {
+              text: 'Loop back to the opening concern.',
+              targetKey: 'intro',
+              endsConversation: false,
+              auxiliaryLink: false,
+              conditions: [],
+              actions: [],
+            },
+          ],
+        },
+      ],
+    });
+
+    const conversationAsset = buildConversationAssetFromDraft(draft, 'K:/Mods/DeadClaim/conversations');
+    const loopBranch = conversationAsset.conversation.nodes[1].branches[0];
+
+    expect(loopBranch.nextNodeIndex).toBe(0);
+    expect(loopBranch.auxiliaryLink).toBe(true);
+  });
+
   it('builds a branch expansion patch without mutating the selected element node', async () => {
     const { buildBranchExpansionPatch } = await import('utils/ai-draft-utils');
     const root = {

--- a/app/src/utils/__tests__/ai-draft-utils.test.ts
+++ b/app/src/utils/__tests__/ai-draft-utils.test.ts
@@ -36,6 +36,7 @@ function makeDraft(overrides: Partial<AiConversationDraftType> = {}): AiConversa
     roots: [
       {
         text: 'Open the briefing.',
+        comment: 'Gate into the opening briefing.',
         targetKey: 'intro',
         endsConversation: false,
         auxiliaryLink: false,
@@ -46,12 +47,14 @@ function makeDraft(overrides: Partial<AiConversationDraftType> = {}): AiConversa
     nodes: [
       {
         key: 'intro',
+        comment: 'Opening contract hook.',
         speaker: { type: 'castId', id: 'DariusDefault' },
         text: 'Commander, this contract has been dead for years, but someone just paid to exhume it.',
         actions: [{ functionName: 'SetFlag', args: [{ type: 'string', value: 'dead_claim_intro' }], note: '' }],
         choices: [
           {
             text: 'Keep talking.',
+            comment: 'Continue to the practical follow-up.',
             targetKey: 'followup',
             endsConversation: false,
             auxiliaryLink: false,
@@ -62,12 +65,14 @@ function makeDraft(overrides: Partial<AiConversationDraftType> = {}): AiConversa
       },
       {
         key: 'followup',
+        comment: 'Darius gives the risk and reward.',
         speaker: { type: 'castId', id: 'DariusDefault' },
         text: 'I do not like the smell of it, but the money is real.',
         actions: [],
         choices: [
           {
             text: 'End briefing.',
+            comment: 'Close the draft conversation.',
             targetKey: '',
             endsConversation: true,
             auxiliaryLink: false,
@@ -102,14 +107,41 @@ describe('AI draft utilities', () => {
     expect(result.errors).toContain("Prompt node key 'intro' is duplicated.");
   });
 
+  it('accepts a response rewrite draft without prompt nodes', async () => {
+    const { validateAiDraft } = await import('utils/ai-draft-utils');
+    const draft = makeDraft({
+      mode: 'nodeSuggestion',
+      nodes: [],
+      roots: [
+        {
+          text: 'Put them through. Darius, keep the Survey Centre hot; I want every scrap of intel before we jump.',
+          comment: 'Sharper closing response for the selected branch.',
+          targetKey: '',
+          endsConversation: true,
+          auxiliaryLink: false,
+          conditions: [],
+          actions: [],
+        },
+      ],
+    });
+
+    const result = validateAiDraft(draft, operations, 'nodeSuggestion', { type: 'response' } as ElementNodeType);
+
+    expect(result.errors).toEqual([]);
+  });
+
   it('turns a full draft into a fresh conversation asset with resolved graph targets', async () => {
     const { buildConversationAssetFromDraft } = await import('utils/ai-draft-utils');
 
     const conversationAsset = buildConversationAssetFromDraft(makeDraft(), 'K:/Mods/DeadClaim/conversations');
 
     expect(conversationAsset.conversation.uiName).toBe('Dead Claim Briefing');
+    expect(conversationAsset.conversation.roots[0].responseText).toBe('');
+    expect(conversationAsset.conversation.roots[0].comment).toBe('Gate into the opening briefing.');
     expect(conversationAsset.conversation.roots[0].nextNodeIndex).toBe(0);
+    expect(conversationAsset.conversation.nodes[0].comment).toBe('Opening contract hook.');
     expect(conversationAsset.conversation.nodes[0].branches[0].nextNodeIndex).toBe(1);
+    expect(conversationAsset.conversation.nodes[0].branches[0].comment).toBe('Continue to the practical follow-up.');
     expect(conversationAsset.conversation.nodes[1].branches[0].nextNodeIndex).toBe(-1);
     expect(conversationAsset.conversation.nodes[0].actions?.ops?.[0].functionName).toBe('SetFlag');
   });

--- a/app/src/utils/ai-artifact-utils.ts
+++ b/app/src/utils/ai-artifact-utils.ts
@@ -1,0 +1,121 @@
+type JsonPrimitive = string | number | boolean | null;
+type JsonObjectValue = { [key: string]: JsonDisplayValue };
+type JsonDisplayValue = JsonPrimitive | JsonDisplayValue[] | JsonObjectValue;
+
+export type AiArtifactDisplayContent = {
+  formattedContent: string;
+  wasFormatted: boolean;
+  notes: string[];
+};
+
+export function formatAiDraftArtifactContent(content: string): AiArtifactDisplayContent {
+  const source = content || '';
+  const parsedWholeContent = parseJson(source);
+
+  if (parsedWholeContent != null) {
+    return {
+      formattedContent: stringifyJson(expandEmbeddedJson(parsedWholeContent)),
+      wasFormatted: true,
+      notes: ['Formatted JSON response.'],
+    };
+  }
+
+  const markdownResult = formatMarkdownJsonBlocks(source);
+  if (markdownResult.wasFormatted) {
+    return markdownResult;
+  }
+
+  return {
+    formattedContent: source,
+    wasFormatted: false,
+    notes: [],
+  };
+}
+
+function formatMarkdownJsonBlocks(content: string): AiArtifactDisplayContent {
+  const notes = new Set<string>();
+  const formattedContent = content.replace(/```json\s*\r?\n([\s\S]*?)```/gi, (match, jsonBlock: string) => {
+    const parsedBlock = parseJson(jsonBlock);
+    if (parsedBlock == null) return match;
+
+    const expandedBlock = expandEmbeddedJson(parsedBlock);
+    notes.add('Formatted prompt JSON block.');
+
+    if (containsExpandedJsonString(parsedBlock, expandedBlock)) {
+      notes.add('Expanded embedded JSON strings inside the prompt request.');
+    }
+
+    return `\`\`\`json\n${stringifyJson(expandedBlock)}\n\`\`\``;
+  });
+
+  return {
+    formattedContent,
+    wasFormatted: notes.size > 0,
+    notes: Array.from(notes),
+  };
+}
+
+function expandEmbeddedJson(value: JsonDisplayValue): JsonDisplayValue {
+  if (typeof value === 'string') {
+    const embeddedJson = parseEmbeddedJsonString(value);
+    return embeddedJson == null ? value : expandEmbeddedJson(embeddedJson);
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => expandEmbeddedJson(item));
+  }
+
+  if (value != null && typeof value === 'object') {
+    const expandedObject: JsonObjectValue = {};
+    for (const [key, childValue] of Object.entries(value)) {
+      expandedObject[key] = expandEmbeddedJson(childValue);
+    }
+
+    return expandedObject;
+  }
+
+  return value;
+}
+
+function containsExpandedJsonString(originalValue: JsonDisplayValue, expandedValue: JsonDisplayValue): boolean {
+  if (typeof originalValue === 'string') {
+    return originalValue !== expandedValue && parseEmbeddedJsonString(originalValue) != null;
+  }
+
+  if (Array.isArray(originalValue) && Array.isArray(expandedValue)) {
+    return originalValue.some((item, index) => containsExpandedJsonString(item, expandedValue[index]));
+  }
+
+  if (isJsonObject(originalValue) && isJsonObject(expandedValue)) {
+    return Object.keys(originalValue).some((key) => containsExpandedJsonString(originalValue[key], expandedValue[key]));
+  }
+
+  return false;
+}
+
+function parseEmbeddedJsonString(value: string): JsonDisplayValue | null {
+  const trimmedValue = value.trim();
+  if (!trimmedValue.startsWith('{') && !trimmedValue.startsWith('[')) return null;
+
+  const parsedValue = parseJson(trimmedValue);
+  if (parsedValue == null || typeof parsedValue !== 'object') return null;
+
+  return parsedValue;
+}
+
+function parseJson(value: string): JsonDisplayValue | null {
+  try {
+    return JSON.parse(value) as JsonDisplayValue;
+  } catch {
+    return null;
+  }
+}
+
+function stringifyJson(value: JsonDisplayValue): string {
+  return JSON.stringify(value, null, 2);
+}
+
+function isJsonObject(value: JsonDisplayValue | undefined): value is JsonObjectValue {
+  return value != null && typeof value === 'object' && !Array.isArray(value);
+}
+

--- a/app/src/utils/ai-draft-utils.ts
+++ b/app/src/utils/ai-draft-utils.ts
@@ -19,9 +19,17 @@ import { createConversation, createPromptNode, createResponseNode, createRootNod
 
 const knownCastIds = new Set([
   'DariusDefault',
+  'castDef_DariusDefault',
   'SumireDefault',
+  'castDef_SumireDefault',
   'YangDefault',
+  'castDef_YangDefault',
   'FarahDefault',
+  'castDef_FarahDefault',
+  'KameaDefault',
+  'castDef_KameaDefault',
+  'MadeiraDefault',
+  'castDef_MadeiraDefault',
   'KrakenIsabella',
   'BladesKai',
   'DEFAULT',

--- a/app/src/utils/ai-draft-utils.ts
+++ b/app/src/utils/ai-draft-utils.ts
@@ -1,0 +1,373 @@
+import { v4 as uuidv4 } from 'uuid';
+
+import {
+  AiAcceptedDraftType,
+  AiBranchExpansionPatchType,
+  AiConversationDraftType,
+  AiDraftChoiceType,
+  AiDraftModeType,
+  AiDraftOperationIntentType,
+  AiDraftValidationResultType,
+  ConversationAssetType,
+  ElementNodeType,
+  OperationArgType,
+  OperationCallType,
+  OperationDefinitionType,
+  PromptNodeType,
+} from 'types';
+import { createConversation, createPromptNode, createResponseNode, createRootNode, getId } from 'utils/conversation-utils';
+
+const knownCastIds = new Set([
+  'DariusDefault',
+  'SumireDefault',
+  'YangDefault',
+  'FarahDefault',
+  'KrakenIsabella',
+  'BladesKai',
+  'DEFAULT',
+  'HOLOGRAM',
+]);
+
+export function parseAiDraft(draftJson: string): AiConversationDraftType {
+  return JSON.parse(draftJson) as AiConversationDraftType;
+}
+
+export function validateAiDraft(
+  draft: AiConversationDraftType | null,
+  operations: OperationDefinitionType[],
+  mode: AiDraftModeType,
+): AiDraftValidationResultType {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  if (draft == null) {
+    return { errors: ['No AI draft has been generated yet.'], warnings };
+  }
+
+  if (draft.mode !== mode) {
+    errors.push(`Draft mode '${draft.mode}' does not match the requested mode '${mode}'.`);
+  }
+
+  if (!draft.title || draft.title.trim() === '') {
+    errors.push('Draft title is blank.');
+  }
+
+  if (!Array.isArray(draft.nodes) || draft.nodes.length === 0) {
+    errors.push('Draft has no prompt nodes.');
+  }
+
+  if (mode === 'fullConversation' && (!Array.isArray(draft.roots) || draft.roots.length === 0)) {
+    errors.push('Full conversation drafts need at least one root choice.');
+  }
+
+  const nodeKeys = new Set<string>();
+  draft.nodes?.forEach((node) => {
+    if (node.key && node.key.trim() !== '') nodeKeys.add(node.key);
+  });
+
+  const seenNodeKeys = new Set<string>();
+  draft.nodes?.forEach((node) => {
+    if (!node.key || node.key.trim() === '') {
+      errors.push('A prompt node has a blank key.');
+    } else if (seenNodeKeys.has(node.key)) {
+      errors.push(`Prompt node key '${node.key}' is duplicated.`);
+    } else {
+      seenNodeKeys.add(node.key);
+    }
+
+    if (!node.text || node.text.trim() === '') {
+      warnings.push(`Prompt node '${node.key}' has blank text.`);
+    }
+
+    validateSpeaker(node.key, node.speaker, warnings);
+    validateOperations(`node '${node.key}' actions`, node.actions, operations, errors);
+    node.choices?.forEach((choice, index) => validateChoice(`node '${node.key}' choice ${index + 1}`, choice, nodeKeys, operations, errors, warnings));
+  });
+
+  draft.roots?.forEach((root, index) => validateChoice(`root ${index + 1}`, root, nodeKeys, operations, errors, warnings));
+  draft.warnings?.forEach((warning) => warnings.push(`AI warning: ${warning}`));
+
+  return { errors, warnings };
+}
+
+function validateSpeaker(nodeKey: string, speaker: { type: string; id: string }, warnings: string[]): void {
+  if (speaker.type === 'none') return;
+
+  if (!speaker.id || speaker.id.trim() === '') {
+    warnings.push(`Prompt node '${nodeKey}' has a speaker type but no speaker id.`);
+    return;
+  }
+
+  if (speaker.type === 'castId' && !knownCastIds.has(speaker.id)) {
+    warnings.push(`Prompt node '${nodeKey}' uses unfamiliar cast id '${speaker.id}'.`);
+  }
+}
+
+function validateChoice(
+  label: string,
+  choice: AiDraftChoiceType,
+  nodeKeys: Set<string>,
+  operations: OperationDefinitionType[],
+  errors: string[],
+  warnings: string[],
+): void {
+  if (!choice.text || choice.text.trim() === '') {
+    warnings.push(`${label} has blank response text.`);
+  }
+
+  if (!choice.endsConversation && (!choice.targetKey || !nodeKeys.has(choice.targetKey))) {
+    errors.push(`${label} points to missing target node '${choice.targetKey}'.`);
+  }
+
+  if (choice.endsConversation && choice.targetKey && choice.targetKey.trim() !== '') {
+    warnings.push(`${label} ends the conversation and also has targetKey '${choice.targetKey}'. The ending will win.`);
+  }
+
+  validateOperations(`${label} conditions`, choice.conditions, operations, errors);
+  validateOperations(`${label} actions`, choice.actions, operations, errors);
+}
+
+function validateOperations(
+  label: string,
+  intents: AiDraftOperationIntentType[] | null | undefined,
+  operations: OperationDefinitionType[],
+  errors: string[],
+): void {
+  if (!intents) return;
+
+  intents.forEach((intent) => {
+    const definition = operations.find((operation) => operation.key === intent.functionName);
+    if (!definition) {
+      errors.push(`${label} references unknown operation '${intent.functionName}'.`);
+      return;
+    }
+
+    if (intent.args.length !== definition.inputs.length) {
+      errors.push(`${label} operation '${intent.functionName}' has ${intent.args.length} args, expected ${definition.inputs.length}.`);
+    }
+  });
+}
+
+export function buildAcceptedDraft(
+  draft: AiConversationDraftType,
+  mode: AiDraftModeType,
+  workingDirectory: string,
+  activeNode: PromptNodeType | ElementNodeType | null,
+): AiAcceptedDraftType {
+  if (mode === 'fullConversation') {
+    return {
+      kind: 'fullConversation',
+      conversationAsset: buildConversationAssetFromDraft(draft, workingDirectory),
+    };
+  }
+
+  if (mode === 'nodeSuggestion') {
+    return {
+      kind: 'nodeText',
+      text: getSuggestedNodeText(draft, activeNode),
+    };
+  }
+
+  if (activeNode == null || activeNode.type === 'node') {
+    throw Error('Branch expansion drafts must be accepted on a root or response node.');
+  }
+
+  return {
+    kind: 'branchExpansion',
+    patch: buildBranchExpansionPatch(draft, activeNode),
+  };
+}
+
+export function buildConversationAssetFromDraft(draft: AiConversationDraftType, workingDirectory: string): ConversationAssetType {
+  const conversationAsset = createConversation(workingDirectory);
+  conversationAsset.conversation.uiName = draft.title || 'AI Draft Conversation';
+  conversationAsset.filename = `${toFileStem(draft.title)}.${conversationAsset.conversation.idRef.id}.convo`;
+  conversationAsset.filepath = `${workingDirectory}/${conversationAsset.filename}.bytes`;
+
+  const nodes = buildPromptNodes(draft);
+  const indexByKey = buildDraftIndexByKey(draft);
+  conversationAsset.conversation.nodes = nodes;
+  conversationAsset.conversation.roots = draft.roots.map((root) => buildElementNode(root, 'root', '0', nodes, indexByKey));
+
+  return conversationAsset;
+}
+
+export function buildPreviewConversationAssetFromDraft(
+  draft: AiConversationDraftType,
+  mode: AiDraftModeType,
+  workingDirectory: string,
+  activeNode: PromptNodeType | ElementNodeType | null,
+): ConversationAssetType | null {
+  if (mode === 'nodeSuggestion') return null;
+  if (mode === 'fullConversation') return buildConversationAssetFromDraft(draft, workingDirectory);
+
+  const conversationAsset = createConversation(workingDirectory);
+  conversationAsset.conversation.uiName = draft.title || 'AI Branch Draft';
+  conversationAsset.filename = `${toFileStem(draft.title)}.${conversationAsset.conversation.idRef.id}.convo`;
+  conversationAsset.filepath = `${workingDirectory}/${conversationAsset.filename}.bytes`;
+
+  const nodes = buildPromptNodes(draft);
+  const previewRoot = createRootNode();
+  previewRoot.parentId = '0';
+  previewRoot.responseText = getBranchPreviewRootText(activeNode);
+  previewRoot.nextNodeIndex = nodes[0]?.index ?? -1;
+  previewRoot.auxiliaryLink = false;
+
+  if (nodes[0]) {
+    nodes[0].parentId = getId(previewRoot);
+  }
+
+  conversationAsset.conversation.roots = [previewRoot];
+  conversationAsset.conversation.nodes = nodes;
+
+  return conversationAsset;
+}
+
+export function buildBranchExpansionPatch(draft: AiConversationDraftType, activeElementNode: ElementNodeType): AiBranchExpansionPatchType {
+  if (activeElementNode.nextNodeIndex !== -1) {
+    throw Error('The selected root or response already points to a prompt node. Clear it before accepting a branch expansion.');
+  }
+
+  const nodes = buildPromptNodes(draft);
+  if (nodes.length === 0) {
+    throw Error('The draft has no prompt nodes to attach.');
+  }
+
+  const parentElementNode = cloneElementNode(activeElementNode);
+  parentElementNode.nextNodeIndex = nodes[0].index;
+  parentElementNode.auxiliaryLink = false;
+  nodes[0].parentId = getId(parentElementNode);
+
+  return {
+    parentElementNode,
+    nodes,
+  };
+}
+
+export function getSuggestedNodeText(draft: AiConversationDraftType, activeNode: PromptNodeType | ElementNodeType | null): string {
+  if (activeNode?.type === 'node') {
+    return draft.nodes[0]?.text || '';
+  }
+
+  return draft.roots[0]?.text || draft.nodes[0]?.choices[0]?.text || '';
+}
+
+function buildPromptNodes(draft: AiConversationDraftType): PromptNodeType[] {
+  const indexByKey = buildDraftIndexByKey(draft);
+
+  return draft.nodes.map((draftNode, index) => {
+    const node = createPromptNode(index);
+    node.text = draftNode.text;
+    node.comment = draftNode.key;
+    node.actions = buildOperationsContainer(draftNode.actions);
+
+    if (draftNode.speaker.type === 'castId') {
+      node.speakerType = 'castId';
+      node.sourceInSceneRef = { id: draftNode.speaker.id };
+      node.speakerOverrideId = '';
+    } else if (draftNode.speaker.type === 'speakerId') {
+      node.speakerType = 'speakerId';
+      node.sourceInSceneRef = null;
+      node.speakerOverrideId = draftNode.speaker.id;
+    } else {
+      node.speakerType = null;
+      node.sourceInSceneRef = null;
+      node.speakerOverrideId = '';
+    }
+
+    node.branches = draftNode.choices.map((choice) => buildElementNode(choice, 'response', getId(node), draft.nodes, indexByKey));
+    return node;
+  });
+}
+
+function buildDraftIndexByKey(draft: AiConversationDraftType): Map<string, number> {
+  const indexByKey = new Map<string, number>();
+  draft.nodes.forEach((node, index) => indexByKey.set(node.key, index));
+  return indexByKey;
+}
+
+function buildElementNode(
+  choice: AiDraftChoiceType,
+  type: 'root' | 'response',
+  parentId: string,
+  nodes: PromptNodeType[] | AiConversationDraftType['nodes'],
+  indexByKey?: Map<string, number>,
+): ElementNodeType {
+  const elementNode = type === 'root' ? createRootNode() : createResponseNode();
+  const targetIndex = choice.endsConversation ? -1 : resolveTargetIndex(choice.targetKey, nodes, indexByKey);
+
+  elementNode.type = type;
+  elementNode.parentId = parentId;
+  elementNode.responseText = choice.text;
+  elementNode.nextNodeIndex = targetIndex;
+  elementNode.auxiliaryLink = choice.auxiliaryLink;
+  elementNode.conditions = buildOperationsContainer(choice.conditions);
+  elementNode.actions = buildOperationsContainer(choice.actions);
+
+  return elementNode;
+}
+
+function resolveTargetIndex(
+  targetKey: string,
+  nodes: PromptNodeType[] | AiConversationDraftType['nodes'],
+  indexByKey?: Map<string, number>,
+): number {
+  if (!targetKey) return -1;
+  if (indexByKey) return indexByKey.get(targetKey) ?? -1;
+
+  const targetNode = (nodes as PromptNodeType[]).find((node) => getId(node) === targetKey || node.comment === targetKey);
+  return targetNode?.index ?? -1;
+}
+
+function buildOperationsContainer(intents: AiDraftOperationIntentType[] | null | undefined): { ops: OperationCallType[] | null } | null {
+  if (!intents || intents.length === 0) return null;
+  return {
+    ops: intents.map(buildOperationCall),
+  };
+}
+
+function getBranchPreviewRootText(activeNode: PromptNodeType | ElementNodeType | null): string {
+  if (activeNode != null && activeNode.type !== 'node' && activeNode.responseText.trim() !== '') {
+    return activeNode.responseText;
+  }
+
+  return 'Preview attached branch';
+}
+
+function buildOperationCall(intent: AiDraftOperationIntentType): OperationCallType {
+  return {
+    functionName: intent.functionName,
+    args: intent.args.map(buildOperationArg),
+  };
+}
+
+function buildOperationArg(arg: { type: string; value: string | number | boolean | null }): OperationArgType {
+  return {
+    type: arg.type === 'bool' ? 'bool' : (arg.type as OperationArgType['type']),
+    intValue: arg.type === 'int' ? Number(arg.value ?? 0) : 0,
+    boolValue: arg.type === 'bool' ? Boolean(arg.value) : false,
+    floatValue: arg.type === 'float' ? Number(arg.value ?? 0) : 0,
+    stringValue: arg.type === 'string' ? String(arg.value ?? '') : '',
+    callValue: null,
+    variableRefValue: null,
+  };
+}
+
+function cloneElementNode(node: ElementNodeType): ElementNodeType {
+  return {
+    ...node,
+    idRef: { id: node.idRef.id },
+    conditions: node.conditions == null ? null : { ops: node.conditions.ops == null ? null : node.conditions.ops.map((op) => ({ ...op })) },
+    actions: node.actions == null ? null : { ops: node.actions.ops == null ? null : node.actions.ops.map((op) => ({ ...op })) },
+  };
+}
+
+function toFileStem(title: string): string {
+  const safeTitle = (title || 'ai-draft')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+  return safeTitle || `ai-draft-${uuidv4().slice(0, 8)}`;
+}

--- a/app/src/utils/ai-draft-utils.ts
+++ b/app/src/utils/ai-draft-utils.ts
@@ -41,6 +41,7 @@ export function validateAiDraft(
   draft: AiConversationDraftType | null,
   operations: OperationDefinitionType[],
   mode: AiDraftModeType,
+  activeNode: PromptNodeType | ElementNodeType | null = null,
 ): AiDraftValidationResultType {
   const errors: string[] = [];
   const warnings: string[] = [];
@@ -55,6 +56,19 @@ export function validateAiDraft(
 
   if (!draft.title || draft.title.trim() === '') {
     errors.push('Draft title is blank.');
+  }
+
+  if (mode === 'nodeSuggestion') {
+    if (activeNode == null) {
+      errors.push('Node suggestion drafts need a selected node.');
+    }
+
+    if (getSuggestedNodeText(draft, activeNode).trim() === '') {
+      errors.push('Node suggestion drafts need suggested text.');
+    }
+
+    draft.warnings?.forEach((warning) => warnings.push(`AI warning: ${warning}`));
+    return { errors, warnings };
   }
 
   if (!Array.isArray(draft.nodes) || draft.nodes.length === 0) {
@@ -89,7 +103,9 @@ export function validateAiDraft(
     node.choices?.forEach((choice, index) => validateChoice(`node '${node.key}' choice ${index + 1}`, choice, nodeKeys, operations, errors, warnings));
   });
 
-  draft.roots?.forEach((root, index) => validateChoice(`root ${index + 1}`, root, nodeKeys, operations, errors, warnings));
+  draft.roots?.forEach((root, index) =>
+    validateChoice(`root ${index + 1}`, root, nodeKeys, operations, errors, warnings, mode === 'fullConversation' && index === 0),
+  );
   draft.warnings?.forEach((warning) => warnings.push(`AI warning: ${warning}`));
 
   return { errors, warnings };
@@ -115,8 +131,9 @@ function validateChoice(
   operations: OperationDefinitionType[],
   errors: string[],
   warnings: string[],
+  allowBlankText = false,
 ): void {
-  if (!choice.text || choice.text.trim() === '') {
+  if (!allowBlankText && (!choice.text || choice.text.trim() === '')) {
     warnings.push(`${label} has blank response text.`);
   }
 
@@ -192,7 +209,9 @@ export function buildConversationAssetFromDraft(draft: AiConversationDraftType, 
   const context = createDraftBuildContext(draft);
   const nodes = buildPromptNodeShells(draft);
   conversationAsset.conversation.nodes = nodes;
-  conversationAsset.conversation.roots = draft.roots.map((root) => buildElementNode(root, 'root', '0', nodes, context));
+  conversationAsset.conversation.roots = draft.roots.map((root, index) =>
+    buildElementNode(root, 'root', '0', nodes, context, index === 0),
+  );
   populatePromptNodeBranches(draft, nodes, context);
 
   return conversationAsset;
@@ -260,10 +279,10 @@ export function buildBranchExpansionPatch(draft: AiConversationDraftType, active
 
 export function getSuggestedNodeText(draft: AiConversationDraftType, activeNode: PromptNodeType | ElementNodeType | null): string {
   if (activeNode?.type === 'node') {
-    return draft.nodes[0]?.text || '';
+    return draft.nodes?.[0]?.text || '';
   }
 
-  return draft.roots[0]?.text || draft.nodes[0]?.choices[0]?.text || '';
+  return draft.roots?.[0]?.text || draft.nodes?.[0]?.choices?.[0]?.text || '';
 }
 
 function createDraftBuildContext(draft: AiConversationDraftType): DraftBuildContext {
@@ -277,7 +296,7 @@ function buildPromptNodeShells(draft: AiConversationDraftType): PromptNodeType[]
   return draft.nodes.map((draftNode, index) => {
     const node = createPromptNode(index);
     node.text = draftNode.text;
-    node.comment = draftNode.key;
+    node.comment = normaliseDraftComment(draftNode.comment);
     node.actions = buildOperationsContainer(draftNode.actions);
 
     if (draftNode.speaker.type === 'castId') {
@@ -316,6 +335,7 @@ function buildElementNode(
   parentId: string,
   nodes: PromptNodeType[],
   context: DraftBuildContext,
+  forceBlankText = false,
 ): ElementNodeType {
   const elementNode = type === 'root' ? createRootNode() : createResponseNode();
   const targetIndex = choice.endsConversation ? -1 : resolveTargetIndex(choice.targetKey, nodes, context.indexByKey);
@@ -324,7 +344,8 @@ function buildElementNode(
 
   elementNode.type = type;
   elementNode.parentId = parentId;
-  elementNode.responseText = choice.text;
+  elementNode.responseText = forceBlankText ? '' : choice.text;
+  elementNode.comment = normaliseDraftComment(choice.comment);
   elementNode.nextNodeIndex = targetIndex;
   elementNode.auxiliaryLink = useAuxiliaryLink;
   elementNode.conditions = buildOperationsContainer(choice.conditions);
@@ -350,6 +371,11 @@ function resolveTargetIndex(
 
   const targetNode = nodes.find((node) => getId(node) === targetKey || node.comment === targetKey);
   return targetNode?.index ?? -1;
+}
+
+function normaliseDraftComment(comment: string | null | undefined): string {
+  if (!comment) return '';
+  return comment.trim();
 }
 
 function buildOperationsContainer(intents: AiDraftOperationIntentType[] | null | undefined): { ops: OperationCallType[] | null } | null {

--- a/app/src/utils/ai-draft-utils.ts
+++ b/app/src/utils/ai-draft-utils.ts
@@ -28,6 +28,11 @@ const knownCastIds = new Set([
   'HOLOGRAM',
 ]);
 
+type DraftBuildContext = {
+  indexByKey: Map<string, number>;
+  structuralParentByIndex: Map<number, string>;
+};
+
 export function parseAiDraft(draftJson: string): AiConversationDraftType {
   return JSON.parse(draftJson) as AiConversationDraftType;
 }
@@ -184,10 +189,11 @@ export function buildConversationAssetFromDraft(draft: AiConversationDraftType, 
   conversationAsset.filename = `${toFileStem(draft.title)}.${conversationAsset.conversation.idRef.id}.convo`;
   conversationAsset.filepath = `${workingDirectory}/${conversationAsset.filename}.bytes`;
 
-  const nodes = buildPromptNodes(draft);
-  const indexByKey = buildDraftIndexByKey(draft);
+  const context = createDraftBuildContext(draft);
+  const nodes = buildPromptNodeShells(draft);
   conversationAsset.conversation.nodes = nodes;
-  conversationAsset.conversation.roots = draft.roots.map((root) => buildElementNode(root, 'root', '0', nodes, indexByKey));
+  conversationAsset.conversation.roots = draft.roots.map((root) => buildElementNode(root, 'root', '0', nodes, context));
+  populatePromptNodeBranches(draft, nodes, context);
 
   return conversationAsset;
 }
@@ -206,7 +212,8 @@ export function buildPreviewConversationAssetFromDraft(
   conversationAsset.filename = `${toFileStem(draft.title)}.${conversationAsset.conversation.idRef.id}.convo`;
   conversationAsset.filepath = `${workingDirectory}/${conversationAsset.filename}.bytes`;
 
-  const nodes = buildPromptNodes(draft);
+  const context = createDraftBuildContext(draft);
+  const nodes = buildPromptNodeShells(draft);
   const previewRoot = createRootNode();
   previewRoot.parentId = '0';
   previewRoot.responseText = getBranchPreviewRootText(activeNode);
@@ -218,6 +225,10 @@ export function buildPreviewConversationAssetFromDraft(
   }
 
   conversationAsset.conversation.roots = [previewRoot];
+  if (nodes[0]) {
+    context.structuralParentByIndex.set(nodes[0].index, getId(previewRoot));
+  }
+  populatePromptNodeBranches(draft, nodes, context);
   conversationAsset.conversation.nodes = nodes;
 
   return conversationAsset;
@@ -228,7 +239,8 @@ export function buildBranchExpansionPatch(draft: AiConversationDraftType, active
     throw Error('The selected root or response already points to a prompt node. Clear it before accepting a branch expansion.');
   }
 
-  const nodes = buildPromptNodes(draft);
+  const context = createDraftBuildContext(draft);
+  const nodes = buildPromptNodeShells(draft);
   if (nodes.length === 0) {
     throw Error('The draft has no prompt nodes to attach.');
   }
@@ -237,6 +249,8 @@ export function buildBranchExpansionPatch(draft: AiConversationDraftType, active
   parentElementNode.nextNodeIndex = nodes[0].index;
   parentElementNode.auxiliaryLink = false;
   nodes[0].parentId = getId(parentElementNode);
+  context.structuralParentByIndex.set(nodes[0].index, getId(parentElementNode));
+  populatePromptNodeBranches(draft, nodes, context);
 
   return {
     parentElementNode,
@@ -252,9 +266,14 @@ export function getSuggestedNodeText(draft: AiConversationDraftType, activeNode:
   return draft.roots[0]?.text || draft.nodes[0]?.choices[0]?.text || '';
 }
 
-function buildPromptNodes(draft: AiConversationDraftType): PromptNodeType[] {
-  const indexByKey = buildDraftIndexByKey(draft);
+function createDraftBuildContext(draft: AiConversationDraftType): DraftBuildContext {
+  return {
+    indexByKey: buildDraftIndexByKey(draft),
+    structuralParentByIndex: new Map<number, string>(),
+  };
+}
 
+function buildPromptNodeShells(draft: AiConversationDraftType): PromptNodeType[] {
   return draft.nodes.map((draftNode, index) => {
     const node = createPromptNode(index);
     node.text = draftNode.text;
@@ -275,8 +294,13 @@ function buildPromptNodes(draft: AiConversationDraftType): PromptNodeType[] {
       node.speakerOverrideId = '';
     }
 
-    node.branches = draftNode.choices.map((choice) => buildElementNode(choice, 'response', getId(node), draft.nodes, indexByKey));
     return node;
+  });
+}
+
+function populatePromptNodeBranches(draft: AiConversationDraftType, nodes: PromptNodeType[], context: DraftBuildContext): void {
+  draft.nodes.forEach((draftNode, index) => {
+    nodes[index].branches = draftNode.choices.map((choice) => buildElementNode(choice, 'response', getId(nodes[index]), nodes, context));
   });
 }
 
@@ -290,32 +314,41 @@ function buildElementNode(
   choice: AiDraftChoiceType,
   type: 'root' | 'response',
   parentId: string,
-  nodes: PromptNodeType[] | AiConversationDraftType['nodes'],
-  indexByKey?: Map<string, number>,
+  nodes: PromptNodeType[],
+  context: DraftBuildContext,
 ): ElementNodeType {
   const elementNode = type === 'root' ? createRootNode() : createResponseNode();
-  const targetIndex = choice.endsConversation ? -1 : resolveTargetIndex(choice.targetKey, nodes, indexByKey);
+  const targetIndex = choice.endsConversation ? -1 : resolveTargetIndex(choice.targetKey, nodes, context.indexByKey);
+  const hasStructuralParent = targetIndex !== -1 && context.structuralParentByIndex.has(targetIndex);
+  const useAuxiliaryLink = targetIndex !== -1 && (choice.auxiliaryLink || hasStructuralParent);
 
   elementNode.type = type;
   elementNode.parentId = parentId;
   elementNode.responseText = choice.text;
   elementNode.nextNodeIndex = targetIndex;
-  elementNode.auxiliaryLink = choice.auxiliaryLink;
+  elementNode.auxiliaryLink = useAuxiliaryLink;
   elementNode.conditions = buildOperationsContainer(choice.conditions);
   elementNode.actions = buildOperationsContainer(choice.actions);
+
+  if (targetIndex !== -1 && !useAuxiliaryLink) {
+    context.structuralParentByIndex.set(targetIndex, getId(elementNode));
+    const targetNode = nodes.find((node) => node.index === targetIndex);
+    if (targetNode) targetNode.parentId = getId(elementNode);
+  }
 
   return elementNode;
 }
 
 function resolveTargetIndex(
   targetKey: string,
-  nodes: PromptNodeType[] | AiConversationDraftType['nodes'],
-  indexByKey?: Map<string, number>,
+  nodes: PromptNodeType[],
+  indexByKey: Map<string, number>,
 ): number {
   if (!targetKey) return -1;
-  if (indexByKey) return indexByKey.get(targetKey) ?? -1;
+  const indexByDraftKey = indexByKey.get(targetKey);
+  if (indexByDraftKey !== undefined) return indexByDraftKey;
 
-  const targetNode = (nodes as PromptNodeType[]).find((node) => getId(node) === targetKey || node.comment === targetKey);
+  const targetNode = nodes.find((node) => getId(node) === targetKey || node.comment === targetKey);
   return targetNode?.index ?? -1;
 }
 

--- a/app/src/utils/conversation-utils.ts
+++ b/app/src/utils/conversation-utils.ts
@@ -6,8 +6,6 @@ import forEachRight from 'lodash.foreachright';
 
 import { ElementNodeType, PromptNodeType, ConversationAssetType, IdRef } from 'types';
 
-import { dataStore } from '../stores';
-
 /* eslint-disable no-param-reassign, no-return-assign */
 export function generateId(): string {
   return `9c${md5(uuidv4()).slice(10)}`;
@@ -22,7 +20,7 @@ export function regenerateNodeIds(conversationAsset: ConversationAssetType): voi
 }
 
 export function regenerateConversationId(conversationAsset: ConversationAssetType): void {
-  dataStore.setConversationId(conversationAsset, generateId());
+  conversationAsset.conversation.idRef.id = generateId();
 }
 
 /*

--- a/app/src/utils/custom-tree-data-utils.ts
+++ b/app/src/utils/custom-tree-data-utils.ts
@@ -5,6 +5,15 @@ import { nodeStore } from '../stores';
 import { changeNodeAtPath, find } from './tree-data-utils';
 import { getId } from './conversation-utils';
 
+type TreeSearchMatch = {
+  node: RSTNode;
+  path: RSTPath;
+};
+
+type TreeSearchResult = {
+  matches: TreeSearchMatch[];
+};
+
 /**
  * Collapses all other branches that aren't on the same branch as the selected node
  *
@@ -108,30 +117,25 @@ export function collapseOrExpandBranches(
 }
 
 function setExpandedInTree(treeData: RSTNode[], nodeId: string, onNode: (node: RSTNode) => void, expanded: boolean): RSTNode[] {
-  const { matches }: { matches: any[] } = find({
+  const { matches } = find({
     treeData,
     searchQuery: undefined,
     searchFocusOffset: undefined,
     getNodeKey: ({ node }: { node: RSTNode }) => node.id,
     searchMethod: ({ node }: { node: RSTNode }) => node.id === nodeId,
     expandFocusMatchPaths: false,
-  });
+  }) as TreeSearchResult;
 
   if (matches == null || matches.length <= 0) return treeData;
 
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const match = matches[0];
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const { path } = match;
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-  const treeNode = match.node as RSTNode;
+  const treeNode = match.node;
   treeNode.expanded = expanded;
   onNode(treeNode);
 
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   return changeNodeAtPath({
     treeData,
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     path,
     newNode: treeNode,
     getNodeKey: ({ node }: { node: RSTNode }) => node.id,

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
        "target": "esnext",
-       "moduleResolution": "node",
+       "moduleResolution": "bundler",
        "module": "esnext",
        "rootDir": ".",
        "resolveJsonModule": true,
@@ -14,16 +14,16 @@
        "isolatedModules": true,
        "noEmit": true,
        "jsx": "react", // change to "react-jsx" when upgrading to React 18
-       "baseUrl": "./",
        "paths": {
-         "components/*": ["src/components/*"],
-         "containers/*": ["src/containers/*"],
-         "services/*": ["src/services/*"],
-         "hooks/*": ["src/hooks/*"],
-         "stores/*": ["src/stores/*"],
-         "utils/*": ["src/utils/*"],
-         "types/*": ["src/types/*"],
-         "types": ["src/types"],
+         "components/*": ["./src/components/*"],
+         "containers/*": ["./src/containers/*"],
+         "services/*": ["./src/services/*"],
+         "hooks/*": ["./src/hooks/*"],
+         "stores/*": ["./src/stores/*"],
+         "utils/*": ["./src/utils/*"],
+         "types/*": ["./src/types/*"],
+         "types": ["./src/types"],
+         "package.json": ["./package.json"],
      }
     }
   }

--- a/config/ai-draft-output.schema.json
+++ b/config/ai-draft-output.schema.json
@@ -34,9 +34,10 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["key", "speaker", "text", "choices", "actions"],
+        "required": ["key", "comment", "speaker", "text", "choices", "actions"],
         "properties": {
           "key": { "type": "string" },
+          "comment": { "type": "string" },
           "speaker": { "$ref": "#/definitions/speaker" },
           "text": { "type": "string" },
           "choices": {
@@ -71,9 +72,10 @@
     "choice": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["text", "targetKey", "endsConversation", "auxiliaryLink", "conditions", "actions"],
+      "required": ["text", "comment", "targetKey", "endsConversation", "auxiliaryLink", "conditions", "actions"],
       "properties": {
         "text": { "type": "string" },
+        "comment": { "type": "string" },
         "targetKey": { "type": "string" },
         "endsConversation": { "type": "boolean" },
         "auxiliaryLink": { "type": "boolean" },

--- a/config/ai-draft-output.schema.json
+++ b/config/ai-draft-output.schema.json
@@ -1,0 +1,115 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ConverseTek AI Conversation Draft",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "mode", "title", "summary", "cast", "roots", "nodes", "warnings"],
+  "properties": {
+    "version": { "type": "integer" },
+    "mode": {
+      "type": "string",
+      "enum": ["fullConversation", "nodeSuggestion", "branchExpansion"]
+    },
+    "title": { "type": "string" },
+    "summary": { "type": "string" },
+    "cast": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "label", "role"],
+        "properties": {
+          "id": { "type": "string" },
+          "label": { "type": "string" },
+          "role": { "type": "string" }
+        }
+      }
+    },
+    "roots": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/choice" }
+    },
+    "nodes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["key", "speaker", "text", "choices", "actions"],
+        "properties": {
+          "key": { "type": "string" },
+          "speaker": { "$ref": "#/definitions/speaker" },
+          "text": { "type": "string" },
+          "choices": {
+            "type": "array",
+            "items": { "$ref": "#/definitions/choice" }
+          },
+          "actions": {
+            "type": "array",
+            "items": { "$ref": "#/definitions/operationIntent" }
+          }
+        }
+      }
+    },
+    "warnings": {
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  },
+  "definitions": {
+    "speaker": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "id"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["castId", "speakerId", "none"]
+        },
+        "id": { "type": "string" }
+      }
+    },
+    "choice": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["text", "targetKey", "endsConversation", "auxiliaryLink", "conditions", "actions"],
+      "properties": {
+        "text": { "type": "string" },
+        "targetKey": { "type": "string" },
+        "endsConversation": { "type": "boolean" },
+        "auxiliaryLink": { "type": "boolean" },
+        "conditions": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/operationIntent" }
+        },
+        "actions": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/operationIntent" }
+        }
+      }
+    },
+    "operationIntent": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["functionName", "args", "note"],
+      "properties": {
+        "functionName": { "type": "string" },
+        "args": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["type", "value"],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": ["string", "int", "float", "bool"]
+              },
+              "value": { "type": ["string", "number", "boolean", "null"] }
+            }
+          }
+        },
+        "note": { "type": "string" }
+      }
+    }
+  }
+}

--- a/config/ai-personalities.json
+++ b/config/ai-personalities.json
@@ -1,0 +1,58 @@
+{
+  "castPersonalities": [
+    {
+      "id": "darius-oliveira",
+      "label": "Darius Oliveira",
+      "castIds": ["DariusDefault", "castDef_DariusDefault"],
+      "speakerIds": ["598cd3f26230355c18000069"],
+      "rules": "Write Darius as the company's professional executive officer: cautious, practical, operations-focused, and usually the person weighing contracts, risk, money, and fallout. He can be dry under pressure, but he should not become flippant or reckless.",
+      "enabled": true,
+      "defaultKey": "darius-oliveira"
+    },
+    {
+      "id": "sumire-meyer",
+      "label": "Sumire Meyer",
+      "castIds": ["SumireDefault", "castDef_SumireDefault"],
+      "speakerIds": ["598cd3a06230355c18000067"],
+      "rules": "Write Sumire with blunt pilot pragmatism: informal, loyal, and direct about travel, debt, danger, and keeping the company alive. She should sound like someone who sees the map, the fuel bill, and the escape vector all at once.",
+      "enabled": true,
+      "defaultKey": "sumire-meyer"
+    },
+    {
+      "id": "yang-virtanen",
+      "label": "Yang Virtanen",
+      "castIds": ["YangDefault", "castDef_YangDefault"],
+      "speakerIds": ["598cd3f36230355c1800006a"],
+      "rules": "Write Yang as a plain-spoken chief MechTech: practical, mechanically minded, good-humoured, and risk-aware. He often calls the Commander \"Boss\" and should ground tension in repairs, machines, logistics, and what might break next.",
+      "enabled": true,
+      "defaultKey": "yang-virtanen"
+    },
+    {
+      "id": "farah-murad",
+      "label": "Farah Murad",
+      "castIds": ["FarahDefault", "castDef_FarahDefault"],
+      "speakerIds": ["59b98a97623035ac140056c6"],
+      "rules": "Write Farah as a brilliant engineer who is excitable, precise, and sometimes apologetic when her enthusiasm or flippancy gets ahead of the situation. She should notice ship systems, technical constraints, and the wonder or danger of old technology.",
+      "enabled": true,
+      "defaultKey": "farah-murad"
+    },
+    {
+      "id": "kamea-arano",
+      "label": "Kamea Arano",
+      "castIds": ["KameaDefault", "castDef_KameaDefault"],
+      "speakerIds": ["59baac916230356416000354"],
+      "rules": "Write Kamea with regal sincerity and the weight of duty. She should sound composed, principled, and Restoration-focused, with personal warmth when speaking to trusted allies and gravity when discussing the Directorate or her people.",
+      "enabled": true,
+      "defaultKey": "kamea-arano"
+    },
+    {
+      "id": "alexander-madeira",
+      "label": "Alexander Madeira",
+      "castIds": ["MadeiraDefault", "castDef_MadeiraDefault"],
+      "speakerIds": ["59b97f45623035ac140054ca"],
+      "rules": "Write Alexander Madeira as formal, strategic, and security-minded. He should be diplomatic and careful with information, often framing decisions in terms of legitimacy, logistics, intelligence, and the Restoration's long-term position.",
+      "enabled": true,
+      "defaultKey": "alexander-madeira"
+    }
+  ]
+}

--- a/config/ai.json
+++ b/config/ai.json
@@ -1,0 +1,10 @@
+{
+  "enabled": true,
+  "selectedProvider": "codex",
+  "codexCommand": "codex",
+  "codexModel": "",
+  "codexProfile": "",
+  "timeoutSeconds": 300,
+  "modelCatalogs": {},
+  "workspaces": {}
+}

--- a/docs/architecture/backend.md
+++ b/docs/architecture/backend.md
@@ -27,6 +27,8 @@ Repo root contains the `.csproj`, `Program.cs`, and the source folders described
 
 Only **GET** and **POST** verbs are exposed by the Chromely version in use — see [`notes.md`](./notes.md).
 
+Avoid registering GET and POST handlers on the exact same path. This Chromely version can collide or shadow routes by path even when the verb differs, which can leave the frontend promise waiting forever. Use unique route paths for paired read/write operations, for example `GET /ai/settings/current` and `POST /ai/settings`.
+
 ## Controllers — `Controllers/`
 
 All controllers register routes in their constructors. Three controllers exist:
@@ -49,6 +51,14 @@ All controllers register routes in their constructors. Three controllers exist:
 - `GET  /colour-config` → reads `config/colours.json`.
 - `POST /working-directory` → sets `FileSystemService.WorkingDirectory`, the folder used for subsequent conversation loads.
 - `GET  /dependency-status` → checks for `ShadowrunDTO.dll` and `ShadowrunSerializer.dll` in `BaseDirectory`.
+
+### `AiController` (Route prefix: `ai`)
+- `GET  /ai/settings/current` -> returns AI provider and workspace settings from `config/ai.json`. This deliberately avoids sharing the same path as the save endpoint because Chromely can clash GET and POST routes on the same path.
+- `POST /ai/settings` -> saves either global settings or one workspace settings block keyed by conversation folder.
+- `POST /ai/models` -> polls the selected provider CLI for the current model catalogue. Codex uses `codex debug models`.
+- `POST /ai/draft` -> runs the selected provider and returns an advisory structured draft plus diagnostic file paths.
+- `POST /ai/draft-artifact` -> reads prompt/response diagnostics from `logs/ai-drafts` for review in the UI. It must remain restricted to that folder.
+- `POST /ai/validate-conversation` -> serialises and reloads a posted conversation asset to check it can round-trip as BattleTech protobuf data before a full AI draft is accepted.
 
 ## Services — `Services/`
 
@@ -74,6 +84,16 @@ All use a singleton `getInstance()` pattern.
 ### `ConfigService`
 - Reads/writes user prefs: `config/quicklinks.json`, `config/colours.json`.
 - Initialises the `config/` directory and placeholder JSON on first use.
+- Also owns `config/ai.json`. Workspace AI settings are stored inside this file by normalised conversation-folder key; do not create per-mod settings files under `conversations/`.
+- `config/ai.json` has a top-level `Enabled`/`enabled` flag. Missing values default to `true`; setting it to `false` hides AI UI entry points and blocks provider actions.
+- AI model catalogues are cached per provider in `config/ai.json`. Saving other AI settings preserves that cache.
+
+### `AiProviderService`
+- Dispatches AI draft requests to the selected provider. The first provider is `codex`; other provider names are reserved for later CLI integrations.
+- Polls provider model catalogues for the settings UI. Normal requests use the saved provider cache when available; explicit refresh repolls the CLI. An empty model override means "provider default/latest".
+- Loads configured context files/folders as read-only prompt context, with extension and size limits.
+- The Codex provider writes diagnostics under `logs/ai-drafts/<timestamp>/`: request JSON, prompt, command, stdout, stderr, and the final `draft.json`.
+- Providers return suggestions only. They do not write conversation files or mutate active conversation state.
 
 ## Handlers — `Handlers/`
 

--- a/docs/architecture/backend.md
+++ b/docs/architecture/backend.md
@@ -8,7 +8,7 @@ Repo root contains the `.csproj`, `Program.cs`, and the source folders described
 
 - `Program.Main()` (lines ~59–136) bootstraps a Chromely CefSharp WinForms host (.NET 4.7.2, win10-x64).
 - **Start URL**: `local://dist/index.html` — serves the React bundle copied to `bin/x64/Debug/net472/dist/` (or release equivalent).
-- **Window**: 1480×900 default, responsive to screen size.
+- **Window**: 1720x1000 default, responsive to screen size.
 - **Logging**: `logs/conversetek-interface.log` and `logs/conversetek-core.log`.
 - **Scheme handlers**:
   - `UseDefaultResourceSchemeHandler("local", ...)` — serves bundle assets.

--- a/docs/architecture/backend.md
+++ b/docs/architecture/backend.md
@@ -87,11 +87,13 @@ All use a singleton `getInstance()` pattern.
 - Also owns `config/ai.json`. Workspace AI settings are stored inside this file by normalised conversation-folder key; do not create per-mod settings files under `conversations/`.
 - `config/ai.json` has a top-level `Enabled`/`enabled` flag. Missing values default to `true`; setting it to `false` hides AI UI entry points and blocks provider actions.
 - AI model catalogues are cached per provider in `config/ai.json`. Saving other AI settings preserves that cache.
+- Workspace AI settings also store editable cast personalities. Missing personality lists are seeded from `config/ai-personalities.json`; explicit empty lists are preserved so modders can remove them.
 
 ### `AiProviderService`
 - Dispatches AI draft requests to the selected provider. The first provider is `codex`; other provider names are reserved for later CLI integrations.
 - Polls provider model catalogues for the settings UI. Normal requests use the saved provider cache when available; explicit refresh repolls the CLI. An empty model override means "provider default/latest".
 - Loads configured context files/folders as read-only prompt context, with extension and size limits.
+- Adds relevant workspace cast-personality rules to the provider prompt by matching the brief, active conversation, and selected node against configured cast ids, speaker ids, labels, and default keys.
 - The Codex provider writes diagnostics under `logs/ai-drafts/<timestamp>/`: request JSON, prompt, command, stdout, stderr, and the final `draft.json`.
 - Providers return suggestions only. They do not write conversation files or mutate active conversation state.
 

--- a/docs/architecture/data-flow.md
+++ b/docs/architecture/data-flow.md
@@ -72,10 +72,10 @@ In parallel, definitions are fetched once via `getDefinitions()` → `GET /defin
 ## 8. Drafting with AI
 
 1. **UI** -> Header AI menu opens a full-conversation draft, or the dialogue tree context menu opens a node rewrite / branch expansion.
-2. **Settings** -> `AiDraftModal` loads `getAiSettings()` and edits global provider options plus workspace context paths, house style notes, and campaign brief.
+2. **Settings** -> `AiDraftModal` loads `getAiSettings()` and edits global provider options plus workspace context paths, house style notes, campaign brief, and cast personalities. Built-in personality restore defaults come from `config/ai-personalities.json`.
 3. **Model polling** -> `getAiModels()` posts current provider settings to `POST /ai/models`. Backend returns the saved provider catalogue when present; otherwise Codex runs `codex debug models`. Refresh forces a new poll. A blank model selection means provider default/latest.
 4. **Request** -> `createAiDraft()` posts the brief, active conversation JSON, selected node JSON, definitions JSON, and working directory to `POST /ai/draft`.
-5. **Backend** -> `AiController` calls `AiProviderService`, which loads configured context files, builds a provider prompt, and runs the selected CLI provider. Codex is the first provider.
+5. **Backend** -> `AiController` calls `AiProviderService`, which loads configured context files, selects relevant cast-personality rules, builds a provider prompt, and runs the selected CLI provider. Codex is the first provider.
 6. **Diagnostics** -> the provider writes prompt/request/stdout/stderr/command/output files under `logs/ai-drafts/<timestamp>/` and returns the structured draft JSON.
 7. **Preview** -> the frontend parses and validates the draft as `AiConversationDraftType`; warnings and errors are shown before acceptance.
 8. **Accept** -> full drafts are round-trip validated through `POST /ai/validate-conversation`, then turned into a fresh active conversation. Node rewrites replace selected text. Branch expansions apply a patch under the selected root/response.

--- a/docs/architecture/data-flow.md
+++ b/docs/architecture/data-flow.md
@@ -69,6 +69,18 @@ In parallel, definitions are fetched once via `getDefinitions()` → `GET /defin
 4. **Frontend** — `lowercasePropertyNames(response, true)` (PascalCase → camelCase) → `defStore.setDefinitions(typed)`.
 5. **Consumption** — `EditableLogic` and `ViewableLogic` look up an operation by `functionName` via `defStore.getDefinition(...)` and render inputs from its `inputs[]` schema. No code change is needed to add a new action — drop a JSON file into `defs/operations/` and rebuild.
 
+## 8. Drafting with AI
+
+1. **UI** -> Header AI menu opens a full-conversation draft, or the dialogue tree context menu opens a node rewrite / branch expansion.
+2. **Settings** -> `AiDraftModal` loads `getAiSettings()` and edits global provider options plus workspace context paths, house style notes, and campaign brief.
+3. **Model polling** -> `getAiModels()` posts current provider settings to `POST /ai/models`. Backend returns the saved provider catalogue when present; otherwise Codex runs `codex debug models`. Refresh forces a new poll. A blank model selection means provider default/latest.
+4. **Request** -> `createAiDraft()` posts the brief, active conversation JSON, selected node JSON, definitions JSON, and working directory to `POST /ai/draft`.
+5. **Backend** -> `AiController` calls `AiProviderService`, which loads configured context files, builds a provider prompt, and runs the selected CLI provider. Codex is the first provider.
+6. **Diagnostics** -> the provider writes prompt/request/stdout/stderr/command/output files under `logs/ai-drafts/<timestamp>/` and returns the structured draft JSON.
+7. **Preview** -> the frontend parses and validates the draft as `AiConversationDraftType`; warnings and errors are shown before acceptance.
+8. **Accept** -> full drafts are round-trip validated through `POST /ai/validate-conversation`, then turned into a fresh active conversation. Node rewrites replace selected text. Branch expansions apply a patch under the selected root/response.
+9. **Dirty state** -> acceptance marks the conversation dirty and triggers a tree rebuild. Rejection discards the draft without touching `unsavedActiveConversationAsset`.
+
 ## Summary diagram
 
 ```
@@ -80,4 +92,5 @@ Export single    | UI -> POST /conversations/export       -> Save (JSON)
 Export all       | UI -> POST /conversations/export-all   -> Loop Save (JSON)
 Import           | UI -> POST /conversations/import       -> Read JSON, Save (BINARY)
 Definitions      | once -> GET /definitions -> DefinitionService.Load -> defStore
+AI draft         | UI -> POST /ai/draft -> AiProviderService -> preview -> explicit accept
 ```

--- a/docs/architecture/domain-model.md
+++ b/docs/architecture/domain-model.md
@@ -144,10 +144,12 @@ AI drafts are an intermediate authoring format, not a BattleTech runtime format.
 
 Important fields:
 - `mode` -> `fullConversation`, `nodeSuggestion`, or `branchExpansion`.
-- `roots[]` -> initial player choices for full drafts.
-- `nodes[]` -> prompt nodes with stable draft `key` values.
-- `choices[]` -> player responses that point to a target draft key or deliberately end the conversation.
+- `roots[]` -> initial player choices for full drafts. The first root of a full conversation is intentionally blank and points at the opening prompt node.
+- `nodes[]` -> prompt nodes with stable draft `key` values plus readable `comment` authoring notes. For prompt-node text suggestions, `nodes[0].text` carries the replacement text.
+- `choices[]` -> player responses that point to a target draft key or deliberately end the conversation. Their `comment` fields describe the branch purpose or condition context.
+- For root/response text suggestions, `roots[0].text` carries the replacement text and is not treated as a graph edge.
 - `actions[]` / `conditions[]` -> operation intents using existing definition `key` names and typed argument values.
+- Prompt nodes without `sourceInSceneRef` or `speakerOverrideId` inherit the current SimGame conversation speaker at runtime. ConverseTek labels these as `Inherits`; BattleTech does not provide a distinct narration speaker for SimGame conversation nodes.
 
 Draft keys are temporary. ConverseTek generates real BattleTech ids and prompt indexes during acceptance. This keeps AI output advisory and prevents preview rendering from mutating the active observable conversation graph.
 

--- a/docs/architecture/domain-model.md
+++ b/docs/architecture/domain-model.md
@@ -138,6 +138,19 @@ Scope-specific tag lists. Example (`commander.json`): `{ "scope": "commander", "
 - `Controllers/DefinitionController.cs` serves it on `GET /definitions`.
 - `app/src/services/api.ts:getDefinitions()` calls it, runs `lowercasePropertyNames` (PascalCase → camelCase), and stores the result in `defStore` via `setDefinitions`.
 
+## AI conversation drafts
+
+AI drafts are an intermediate authoring format, not a BattleTech runtime format. They are shaped by `app/src/types/AiDraftType.ts` and the provider schema in `config/ai-draft-output.schema.json`.
+
+Important fields:
+- `mode` -> `fullConversation`, `nodeSuggestion`, or `branchExpansion`.
+- `roots[]` -> initial player choices for full drafts.
+- `nodes[]` -> prompt nodes with stable draft `key` values.
+- `choices[]` -> player responses that point to a target draft key or deliberately end the conversation.
+- `actions[]` / `conditions[]` -> operation intents using existing definition `key` names and typed argument values.
+
+Draft keys are temporary. ConverseTek generates real BattleTech ids and prompt indexes during acceptance. This keeps AI output advisory and prevents preview rendering from mutating the active observable conversation graph.
+
 ## Other notable types (frontend)
 
 | Type | File | Purpose |

--- a/docs/architecture/frontend.md
+++ b/docs/architecture/frontend.md
@@ -42,7 +42,8 @@ Containers consume stores by key: `useStore<DataStore>('data')`, `useStore<NodeS
 
 ## Major UI surfaces (containers)
 
-- `Header` — File menu (Open Folder, Save, Import/Export, Export All), top nav. Reads `dataStore.workingDirectory`, `dataStore.activeConversationAsset`.
+- `Header` — File menu (Open Folder, Save, Import/Export, Export All), AI menu, top nav. Reads `dataStore.workingDirectory`, `dataStore.activeConversationAsset`.
+- `AiDraftModal` — AI-assisted conversation drafting and suggestion review. It stores draft preview state locally, validates it, and only applies changes when the user accepts.
 - `Conversations` — Top-level layout; loads conversations + definitions on mount; switches between `ConversationEditor` and `SplashScreen`.
 - `ConversationTree` — Left sidebar list of conversations.
 - `ConversationEditor` — Main workspace; hosts `ConversationGeneral`, `ConversationActions`, `ConversationConditions` and the dialogue tree.
@@ -60,8 +61,18 @@ Containers consume stores by key: `useStore<DataStore>('data')`, `useStore<NodeS
 
 `app/src/services/api.ts`
 - High-level operations layered over `rest.ts`. Knows the routes (`/conversations`, `/conversations/put`, `/conversations/export`, `/conversations/export-all`, `/conversations/import`, `/conversations/delete`, `/definitions`, `/filesystem`, `/directories`, `/quicklinks`, `/colour-config`, `/working-directory`, `/dependency-status`).
+- Also wraps AI routes (`/ai/settings`, `/ai/models`, `/ai/draft`, `/ai/validate-conversation`) for provider settings, model polling, draft generation, and backend round-trip validation.
 - Handles preprocessing (`consolidateSpeaker`, `removeAllOldFillerNodes`, `rebuildNodeIndexes`) before sending writes.
 - Updates stores after responses (`dataStore.setConversations`, `defStore.setDefinitions`, etc.).
+
+## AI drafting flow
+
+- Whole-conversation drafts are opened from the Header `AI` menu. Node rewrites and branch expansion are opened from the dialogue tree context menu.
+- AI entry points are gated by `config/ai.json` `Enabled`/`enabled`, defaulting to on. When disabled, the Header AI menu and dialogue-tree AI context actions are hidden.
+- The model selector loads the saved provider catalogue first, polls the provider CLI when no cache exists, and only repolls on `Refresh`. It keeps an empty value as "provider default/latest" so drafts are not pinned unless the user chooses a specific model.
+- AI responses are parsed as `AiConversationDraftType`, rendered as a read-only tree preview where possible, and validated before acceptance. Prompt and response diagnostics can be opened from the draft metadata panel.
+- `app/src/utils/ai-draft-utils.ts` converts drafts with pure functions. Full drafts produce a fresh `ConversationAssetType`; branch expansion produces a patch with a cloned parent root/response and new prompt nodes; node suggestions produce replacement text.
+- Accepting a draft is the only point where MobX state changes. The accept handler applies one deliberate action, marks the conversation dirty, and triggers a tree rebuild.
 
 ## Snake_case ↔ camelCase mapping
 

--- a/docs/architecture/frontend.md
+++ b/docs/architecture/frontend.md
@@ -43,7 +43,7 @@ Containers consume stores by key: `useStore<DataStore>('data')`, `useStore<NodeS
 ## Major UI surfaces (containers)
 
 - `Header` — File menu (Open Folder, Save, Import/Export, Export All), AI menu, top nav. Reads `dataStore.workingDirectory`, `dataStore.activeConversationAsset`.
-- `AiDraftModal` — AI-assisted conversation drafting and suggestion review. It stores draft preview state locally, validates it, and only applies changes when the user accepts.
+- `AiDraftModal` — AI-assisted conversation drafting, suggestion review, provider settings, and workspace cast-personality editing. It stores draft preview state locally, validates it, and only applies changes when the user accepts.
 - `Conversations` — Top-level layout; loads conversations + definitions on mount; switches between `ConversationEditor` and `SplashScreen`.
 - `ConversationTree` — Left sidebar list of conversations.
 - `ConversationEditor` — Main workspace; hosts `ConversationGeneral`, `ConversationActions`, `ConversationConditions` and the dialogue tree.
@@ -70,6 +70,7 @@ Containers consume stores by key: `useStore<DataStore>('data')`, `useStore<NodeS
 - Whole-conversation drafts are opened from the Header `AI` menu. Node rewrites and branch expansion are opened from the dialogue tree context menu.
 - AI entry points are gated by `config/ai.json` `Enabled`/`enabled`, defaulting to on. When disabled, the Header AI menu and dialogue-tree AI context actions are hidden.
 - The model selector loads the saved provider catalogue first, polls the provider CLI when no cache exists, and only repolls on `Refresh`. It keeps an empty value as "provider default/latest" so drafts are not pinned unless the user chooses a specific model.
+- Workspace AI settings include context paths, house style notes, campaign brief, and editable cast personalities. Cast personalities link rules to cast ids and speaker ids so generated dialogue can stay in character for vanilla and custom casts; built-in restore defaults are supplied by `config/ai-personalities.json`.
 - AI responses are parsed as `AiConversationDraftType`, rendered as a read-only tree preview where possible, and validated before acceptance. Prompt and response diagnostics can be opened from the draft metadata panel.
 - `app/src/utils/ai-draft-utils.ts` converts drafts with pure functions. Full drafts produce a fresh `ConversationAssetType`; branch expansion produces a patch with a cloned parent root/response and new prompt nodes; node suggestions produce replacement text.
 - Accepting a draft is the only point where MobX state changes. The accept handler applies one deliberate action, marks the conversation dirty, and triggers a tree rebuild.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -62,7 +62,7 @@ Chromely is lightweight and lets the backend stay in C# / .NET so it can reuse B
 | Backend source | `Controllers/`, `Services/`, `Handlers/`, `Data/`, `Json/`, `Program.cs` | Auto-discovered by Chromely's `ScanAssemblies()` |
 | Definition packs | `defs/operations/`, `defs/presets/`, `defs/tags/` | JSON, drives dynamic UI (see `domain-model.md`) |
 | Game DLLs | `libs/` | `ShadowrunDTO.dll`, `ShadowrunSerializer.dll` (gitignored) |
-| User config | `config/quicklinks.json`, `config/colours.json`, `config/ai.json` | Created on first run where needed |
+| User config | `config/quicklinks.json`, `config/colours.json`, `config/ai.json`, `config/ai-personalities.json` | Created or copied where needed |
 | Logs | `logs/conversetek-*.log` | Interface and Chromely core logs |
 | Build tasks | `.vscode/tasks.json` | `Build All`, `UI Build`, `UI Install`, `Fast Run`, `Release` |
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -62,7 +62,7 @@ Chromely is lightweight and lets the backend stay in C# / .NET so it can reuse B
 | Backend source | `Controllers/`, `Services/`, `Handlers/`, `Data/`, `Json/`, `Program.cs` | Auto-discovered by Chromely's `ScanAssemblies()` |
 | Definition packs | `defs/operations/`, `defs/presets/`, `defs/tags/` | JSON, drives dynamic UI (see `domain-model.md`) |
 | Game DLLs | `libs/` | `ShadowrunDTO.dll`, `ShadowrunSerializer.dll` (gitignored) |
-| User config | `config/quicklinks.json`, `config/colours.json` | Created on first run |
+| User config | `config/quicklinks.json`, `config/colours.json`, `config/ai.json` | Created on first run where needed |
 | Logs | `logs/conversetek-*.log` | Interface and Chromely core logs |
 | Build tasks | `.vscode/tasks.json` | `Build All`, `UI Build`, `UI Install`, `Fast Run`, `Release` |
 
@@ -71,6 +71,7 @@ Chromely is lightweight and lets the backend stay in C# / .NET so it can reuse B
 - **Definition-driven UI.** Actions, conditions, presets, and tag scopes are defined as JSON under `defs/`. The backend loads them at startup and the frontend renders argument inputs dynamically from these definitions — no UI code change is needed to add a new action. See `domain-model.md`.
 - **Reuse of game assemblies.** Binary `.bytes` files are read/written through BattleTech's own protobuf types via `protobuf-net`, sidestepping a from-scratch reverse engineering effort.
 - **Tree-based dialogue editor.** Nodes are PromptNodes (NPC/game-spoken) with `branches[]` of ElementNodes (player responses). Loops are expressed as link nodes pointing back to existing nodes.
+- **Advisory AI drafting.** Codex CLI can draft whole conversations, node rewrites, or branch expansions through a generic provider layer. Drafts stay outside the MobX conversation graph until the user accepts them.
 
 ## Build & run, briefly
 


### PR DESCRIPTION
Adds the first pass of conversation assist drafting for ConverseTek. This includes the draft modal, model settings, prompt diagnostics, validation, and the cast personality rules used to keep generated dialogue closer to the intended BattleTech voices.

The cast personalities are workspace editable, with default BattleTech crew guidance stored in config/ai-personalities.json so it can be changed without hard-coding the voice rules into the app.